### PR TITLE
 fix: no bundled dependencies in auth-provider package

### DIFF
--- a/packages/auth-provider/project.json
+++ b/packages/auth-provider/project.json
@@ -15,7 +15,7 @@
     "lint": {
       "executor": "@nx/eslint:lint"
     },
-    "release": {
+    "nx-release-publish": {
       "executor": "nx:run-commands",
       "options": {
         "cwd": "packages/auth-provider",


### PR DESCRIPTION
What happend

* publib-npm was not called during release
* nx release does not support bundled dependencies https://github.com/nrwl/nx/issues/21789

Fix:

replace `nx-release-publish` command with `publib-npm` call which supports bundled dependencies