### PR TITLE
fix(auth-provider): install deps before build

### DIFF
--- a/packages/auth-provider/project.json
+++ b/packages/auth-provider/project.json
@@ -5,12 +5,22 @@
   "projectType": "library",
   "private": false,
   "targets": {
+    "install-node-modules": {
+      "executor": "nx:run-commands",
+        "options": {
+          "cwd": "packages/auth-provider",
+          "command": "npm i --prefix ."
+      }
+    },
     "build": {
       "executor": "nx:run-commands",
       "options": {
         "cwd": "packages/auth-provider",
         "command": "npm run build"
-      }
+      },
+      "dependsOn": [
+        "install-node-modules"
+      ]
     },
     "lint": {
       "executor": "@nx/eslint:lint"


### PR DESCRIPTION
node_modules has to be installed in package folder for publish process to pick-up them