### PR TITLE
docs: remove redundant variable from class initialization in readme

### DIFF
--- a/packages/auth-provider/README.md
+++ b/packages/auth-provider/README.md
@@ -21,7 +21,6 @@ const authProvider = new AuthProvider({
   tokenId,
   passphrase,
   privateKey,
-  publicKey,
   projectId,
   tokenEndpoint,
 })
@@ -62,7 +61,6 @@ stats = {
   tokenId,
   passphrase,
   privateKey,
-  publicKey,
   projectId,
   tokenEndpoint,
 }


### PR DESCRIPTION
PAT publicKey is not needed for TDK AuthProvider initialization.