### PR TITLE
feat(python): enable publishing of jsii packages to pypi

### DIFF
--- a/.github/workflows/nx-release.yaml
+++ b/.github/workflows/nx-release.yaml
@@ -20,6 +20,10 @@ jobs:
     concurrency: release
     runs-on: ubuntu-latest
     environment: main
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+      contents: read    
     needs:
       - security
     steps:
@@ -47,6 +51,10 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           scope: '@affinidi-tdk'
       - run: npm ci
+      
+      - name: build
+        run: |
+          npx nx run-many -t build
       # Generate tag/changelog with semantic release
       # setting parallel higher than one might cause problems with locking git repo
       - run: npx nx run-many  -t semantic-release --parallel=false
@@ -54,6 +62,23 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: package
+        run: |
+          npx nx run-many -t package 
+      
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.x'
+
+      - name:  install twine for pypi releases
+        run: |
+          pip install twine
+
+      - name: Mint pypi token
+        id: mint
+        uses: tschm/token-mint-action@v1.0.3
 
       # Publish to npm with new nx release publish functionality
       - run: |
@@ -63,3 +88,5 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }} #publib-npm expects this 
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+          TWINE_USERNAME: '__token__'
+          TWINE_PASSWORD: ${{ steps.mint.outputs.api-token }}

--- a/libs/iota-core/README.md
+++ b/libs/iota-core/README.md
@@ -1,14 +1,23 @@
-## @affinidi/iota-core
+# @affinidi/iota-core
 
-### Installation
+## Install
+
+### Javascript
 
 ```bash
 npm install @affinidi-tdk/iota-core
 ```
 
-### Usage
+### Python
+
+run inside [python virtual env](https://docs.python.org/3/library/venv.html)
+
+```bash
+pip install affinidi_tdk_common
+```
+
+## Usage
 
 Head over to [Affinidi Iota Framework documentation](https://docs.affinidi.com/services/iota-framework) page to better understand how the service works.
 
 For details on how to use this library please head over to [iota-core documentation](https://docs.affinidi.com/dev-tools/affinidi-tdk/libraries/iota-core) page.
-

--- a/libs/iota-core/package.json
+++ b/libs/iota-core/package.json
@@ -25,7 +25,7 @@
     "versionFormat": "short",
     "targets": {
       "python": {
-        "distName": "affinidi-tdk_iota-core",
+        "distName": "affinidi_tdk_iota_core",
         "module": "affinidi_tdk_iota_core"
       }
     }
@@ -36,7 +36,8 @@
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
     "package": "jsii-pacmak -vvv",
-    "publib-npm": "publib-npm"
+    "publish-npm": "publib-npm",
+    "publish-pypi": "twine upload --verbose --skip-existing dist/python/*"
   },
   "dependencies": {
     "@affinidi-tdk/common": "^1.1.1",

--- a/libs/iota-core/project.json
+++ b/libs/iota-core/project.json
@@ -7,32 +7,35 @@
   "targets": {
     "install-node-modules": {
       "executor": "nx:run-commands",
-      "options": {
-        "cwd": "libs/iota-core",
-        "command": "npm i --prefix ."
+        "options": {
+        "cwd": "{projectRoot}",
+          "command": "npm i --prefix ."
       }
     },
     "build": {
       "executor": "nx:run-commands",
       "options": {
-        "cwd": "libs/iota-core",
+        "cwd": "{projectRoot}",
         "command": "npm run build"
       },
-      "dependsOn": ["install-node-modules"]
+      "dependsOn": [
+        "install-node-modules"
+      ],
+       "outputs": [
+        "{projectRoot}/.jsii"
+       ]
     },
-    "lint": {
-      "executor": "@nx/eslint:lint"
-    },
-    "nx-release-publish": {
+    "package": {
       "executor": "nx:run-commands",
       "options": {
-        "cwd": "libs/iota-core",
-        "command": "npm run publib-npm"
+        "cwd": "{projectRoot}",
+        "command": "npm run package"
       },
       "dependsOn": [
-        {
-          "target": "build"
-        }
+        "build"
+      ], 
+      "outputs": [
+        "{projectRoot}/dist/"
       ]
     },
     "semantic-release": {

--- a/packages/auth-provider/README.md
+++ b/packages/auth-provider/README.md
@@ -2,53 +2,27 @@
 
 Affinidi TDK Internal module for managing access tokens.
 
-## Javascript
+## Install
 
-### Install
+### Javascript
 
 ```bash
 npm install @affinidi-tdk/auth-provider
 ```
 
-### Usage
-
-```ts
-import { AuthProvider } from '@affinidi-tdk/auth-provider'
-
-const authProvider = new AuthProvider({
-  apiGatewayUrl,
-  keyId,
-  tokenId,
-  passphrase,
-  privateKey,
-  projectId,
-  tokenEndpoint,
-})
-
-const projectScopedToken = await authProvider.fetchProjectScopedToken()
-```
-
 ## Python
-
-### Build JSII python package
-
-This is step is required, as python package is not published to pypi.org yet
-
-```bash
-git clone git@github.com:affinidi/affinidi-tdk.git
-cd packages/auth-provider/
-npm i --prefix .
-npm run build
-npm run package
-```
 
 ### Install Python package
 
-After Build Step, run inside [python virtual env](https://docs.python.org/3/library/venv.html)
+run inside [python virtual env](https://docs.python.org/3/library/venv.html)
 
 ```bash
-pip install dist/python/affinidi_tdk_auth_provider-0.1.4-py3-none-any.whl
+pip install affinidi_tdk_auth_provider
 ```
+
+
+## Usage
+
 
 ### Python package usage
 
@@ -68,4 +42,38 @@ stats = {
 authProvider = affinidi_tdk_auth_provider.AuthProvider(stats)
 
 projectScopedToken = authProvider.fetch_project_scoped_token()
+```
+
+### Javascript package usage
+
+```ts
+import { AuthProvider } from '@affinidi-tdk/auth-provider'
+
+const authProvider = new AuthProvider({
+  apiGatewayUrl,
+  keyId,
+  tokenId,
+  passphrase,
+  privateKey,
+  projectId,
+  tokenEndpoint,
+})
+
+const projectScopedToken = await authProvider.fetchProjectScopedToken()
+```
+
+### Mnually Build JSII python package
+
+This is step is required, as python package is not published to pypi.org yet
+
+```bash
+git clone git@github.com:affinidi/affinidi-tdk.git
+cd packages/auth-provider/
+npm i --prefix .
+npm run build
+npm run package
+```
+
+```bash
+pip install dist/python/affinidi_tdk_auth_provider-0.1.4-py3-none-any.whl
 ```

--- a/packages/auth-provider/package.json
+++ b/packages/auth-provider/package.json
@@ -24,7 +24,7 @@
     "versionFormat": "short",
     "targets": {
       "python": {
-        "distName": "affinidi-tdk_auth-provider",
+        "distName": "affinidi_tdk_auth_provider",
         "module": "affinidi_tdk_auth_provider"
       }
     }
@@ -35,7 +35,8 @@
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
     "package": "jsii-pacmak -vvv",
-    "publib-npm": "publib-npm"
+    "publish-npm": "publib-npm",
+    "publish-pypi": "twine upload --verbose --skip-existing dist/python/*"
   },
   "dependencies": {
     "@affinidi-tdk/common": "^1.0.0",

--- a/packages/auth-provider/project.json
+++ b/packages/auth-provider/project.json
@@ -8,18 +8,34 @@
     "install-node-modules": {
       "executor": "nx:run-commands",
         "options": {
-          "cwd": "packages/auth-provider",
+        "cwd": "{projectRoot}",
           "command": "npm i --prefix ."
       }
     },
     "build": {
       "executor": "nx:run-commands",
       "options": {
-        "cwd": "packages/auth-provider",
+        "cwd": "{projectRoot}",
         "command": "npm run build"
       },
       "dependsOn": [
         "install-node-modules"
+      ],
+       "outputs": [
+        "{projectRoot}/.jsii"
+       ]
+    },
+    "package": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "{projectRoot}",
+        "command": "npm run package"
+      },
+      "dependsOn": [
+        "build"
+      ], 
+      "outputs": [
+        "{projectRoot}/dist/"
       ]
     },
     "lint": {
@@ -28,14 +44,12 @@
     "nx-release-publish": {
       "executor": "nx:run-commands",
       "options": {
-        "cwd": "packages/auth-provider",
-        "command": "npm run publib-npm"
-      },
-      "dependsOn": [
-        {
-          "target": "build"
-        }
-      ]
+        "cwd": "{projectRoot}",
+        "commands": [
+          "npm run publish-pypi",
+          "npm run publish-npm"
+        ]
+      }
     },
     "semantic-release": {
       "executor": "@theunderscorer/nx-semantic-release:semantic-release",

--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -1,20 +1,27 @@
 ## @affinidi-tdk/common
 
-### Build JSII
+## Install
 
+### Javascript
+
+```bash
+npm install @affinidi-tdk/common
 ```
+
+## Python
+
+run inside [python virtual env](https://docs.python.org/3/library/venv.html)
+
+```bash
+pip install affinidi_tdk_common
+```
+
+## Manually build package
+
+```bash
 npm i --prefix .
 npm run build
 npm run package
 ```
 
 The code will be generated under /dist for each language.
-
-### Usage
-
-### JS
-
-```bash
-npm install @affinidi-tdk/common
-```
-

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -24,7 +24,7 @@
     "versionFormat": "short",
     "targets": {
       "python": {
-        "distName": "affinidi-tdk_common",
+        "distName": "affinidi_tdk_common",
         "module": "affinidi_tdk_common"
       }
     }
@@ -35,7 +35,8 @@
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
     "package": "jsii-pacmak -vvv",
-    "publib-npm": "publib-npm"
+    "publish-npm": "publib-npm",
+    "publish-pypi": "twine upload --verbose --skip-existing dist/python/*"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^7.4.0",

--- a/packages/common/project.json
+++ b/packages/common/project.json
@@ -7,32 +7,35 @@
   "targets": {
     "install-node-modules": {
       "executor": "nx:run-commands",
-      "options": {
-        "cwd": "packages/common",
-        "command": "npm i --prefix ."
+        "options": {
+        "cwd": "{projectRoot}",
+          "command": "npm i --prefix ."
       }
     },
     "build": {
       "executor": "nx:run-commands",
       "options": {
-        "cwd": "packages/common",
+        "cwd": "{projectRoot}",
         "command": "npm run build"
       },
-      "dependsOn": ["install-node-modules"]
+      "dependsOn": [
+        "install-node-modules"
+      ],
+       "outputs": [
+        "{projectRoot}/.jsii"
+       ]
     },
-    "lint": {
-      "executor": "@nx/eslint:lint"
-    },
-    "nx-release-publish": {
+    "package": {
       "executor": "nx:run-commands",
       "options": {
-        "cwd": "packages/common",
-        "command": "npm run publib-npm"
+        "cwd": "{projectRoot}",
+        "command": "npm run package"
       },
       "dependsOn": [
-        {
-          "target": "build"
-        }
+        "build"
+      ], 
+      "outputs": [
+        "{projectRoot}/dist/"
       ]
     },
     "semantic-release": {


### PR DESCRIPTION
1) enables releases of jsii packages to pypi:
* auth-provider
* common
* iota-core

2) documentation updated

3) package names for python fixed. (underscores are not supported in package name)

4) pypi trusted publisher(oidc auth) is used to release packages to pypi