### PR TITLE
fix: publish process - always pick last commit

### DIFF
--- a/.github/workflows/nx-release.yaml
+++ b/.github/workflows/nx-release.yaml
@@ -77,7 +77,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
+          ref: ${{ github.ref }}
+          
       - uses: actions/setup-node@v4
         with:
           node-version: 18


### PR DESCRIPTION
fixes issue when publishing process is not picking up last commit done by release job.
