### PR TITLE
fix: revert parameter name

### DIFF
--- a/packages/auth-provider/auth-provider.ts
+++ b/packages/auth-provider/auth-provider.ts
@@ -37,7 +37,8 @@ export class AuthProvider {
   private readonly iotaInstance: Iota
 
   constructor(param: { [key: string]: string }) {
-    this.apiGatewayUrl = param?.apiGW ?? EnvironmentUtils.fetchApiGwUrl()
+    this.apiGatewayUrl =
+      param?.apiGatewayUrl ?? EnvironmentUtils.fetchApiGwUrl()
     this.tokenEndpoint =
       param?.tokenEndpoint ?? EnvironmentUtils.fetchElementsAuthTokenUrl()
 


### PR DESCRIPTION
Use `apiGatewayUrl` as a parameter name. 