### PR TITLE
fix: avoid empty releases by ignoring package.lock.json

### DIFF
--- a/.nxignore
+++ b/.nxignore
@@ -1,0 +1,1 @@
+package-lock.json


### PR DESCRIPTION
fixes issue with over releeasing empty changes of libraries