### PR TITLE
Replaced /affinidi.com/ with /affinidi/ for all  github links.

### DIFF
--- a/clients/dart/credential_issuance_client/README.md
+++ b/clients/dart/credential_issuance_client/README.md
@@ -22,7 +22,7 @@ If this Dart package is published to Github, add the following dependency to you
 ```
 dependencies:
   affinidi_tdk_credential_issuance_client:
-    git: https://github.com/affinidi.com/affinidi-tdk.git
+    git: https://github.com/affinidi/affinidi-tdk.git
 ```
 
 ### Local

--- a/clients/dart/credential_verification_client/README.md
+++ b/clients/dart/credential_verification_client/README.md
@@ -22,7 +22,7 @@ If this Dart package is published to Github, add the following dependency to you
 ```
 dependencies:
   affinidi_tdk_credential_verification_client:
-    git: https://github.com/affinidi.com/affinidi-tdk.git
+    git: https://github.com/affinidi/affinidi-tdk.git
 ```
 
 ### Local

--- a/clients/dart/iam_client/README.md
+++ b/clients/dart/iam_client/README.md
@@ -22,7 +22,7 @@ If this Dart package is published to Github, add the following dependency to you
 ```
 dependencies:
   affinidi_tdk_iam_client:
-    git: https://github.com/affinidi.com/affinidi-tdk.git
+    git: https://github.com/affinidi/affinidi-tdk.git
 ```
 
 ### Local

--- a/clients/dart/iota_client/README.md
+++ b/clients/dart/iota_client/README.md
@@ -22,7 +22,7 @@ If this Dart package is published to Github, add the following dependency to you
 ```
 dependencies:
   affinidi_tdk_iota_client:
-    git: https://github.com/affinidi.com/affinidi-tdk.git
+    git: https://github.com/affinidi/affinidi-tdk.git
 ```
 
 ### Local

--- a/clients/dart/login_configuration_client/README.md
+++ b/clients/dart/login_configuration_client/README.md
@@ -22,7 +22,7 @@ If this Dart package is published to Github, add the following dependency to you
 ```
 dependencies:
   affinidi_tdk_login_configuration_client:
-    git: https://github.com/affinidi.com/affinidi-tdk.git
+    git: https://github.com/affinidi/affinidi-tdk.git
 ```
 
 ### Local

--- a/clients/dart/wallets_client/README.md
+++ b/clients/dart/wallets_client/README.md
@@ -22,7 +22,7 @@ If this Dart package is published to Github, add the following dependency to you
 ```
 dependencies:
   affinidi_tdk_wallets_client:
-    git: https://github.com/affinidi.com/affinidi-tdk.git
+    git: https://github.com/affinidi/affinidi-tdk.git
 ```
 
 ### Local

--- a/clients/python/credential_issuance_client/pyproject.toml
+++ b/clients/python/credential_issuance_client/pyproject.toml
@@ -5,7 +5,7 @@ description = "CredentialIssuanceService"
 authors = ["Affinidi <info@affinidi.com>"]
 license = "Apache-2.0"
 readme = "README.md"
-repository = "https://github.com/affinidi.com/affinidi-tdk"
+repository = "https://github.com/affinidi/affinidi-tdk"
 keywords = ["OpenAPI", "OpenAPI-Generator", "CredentialIssuanceService"]
 include = ["affinidi_tdk_credential_issuance_client/py.typed"]
 

--- a/clients/python/credential_verification_client/pyproject.toml
+++ b/clients/python/credential_verification_client/pyproject.toml
@@ -5,7 +5,7 @@ description = "VerificationService"
 authors = ["Affinidi <info@affinidi.com>"]
 license = "Apache-2.0"
 readme = "README.md"
-repository = "https://github.com/affinidi.com/affinidi-tdk"
+repository = "https://github.com/affinidi/affinidi-tdk"
 keywords = ["OpenAPI", "OpenAPI-Generator", "VerificationService"]
 include = ["affinidi_tdk_credential_verification_client/py.typed"]
 

--- a/clients/python/iam_client/pyproject.toml
+++ b/clients/python/iam_client/pyproject.toml
@@ -5,7 +5,7 @@ description = "Iam"
 authors = ["Affinidi <info@affinidi.com>"]
 license = "Apache-2.0"
 readme = "README.md"
-repository = "https://github.com/affinidi.com/affinidi-tdk"
+repository = "https://github.com/affinidi/affinidi-tdk"
 keywords = ["OpenAPI", "OpenAPI-Generator", "Iam"]
 include = ["affinidi_tdk_iam_client/py.typed"]
 

--- a/clients/python/iota_client/pyproject.toml
+++ b/clients/python/iota_client/pyproject.toml
@@ -5,7 +5,7 @@ description = "IotaService"
 authors = ["Affinidi <info@affinidi.com>"]
 license = "Apache-2.0"
 readme = "README.md"
-repository = "https://github.com/affinidi.com/affinidi-tdk"
+repository = "https://github.com/affinidi/affinidi-tdk"
 keywords = ["OpenAPI", "OpenAPI-Generator", "IotaService"]
 include = ["affinidi_tdk_iota_client/py.typed"]
 

--- a/clients/python/login_configuration_client/pyproject.toml
+++ b/clients/python/login_configuration_client/pyproject.toml
@@ -5,7 +5,7 @@ description = "OidcVpAdapterBackend"
 authors = ["Affinidi <info@affinidi.com>"]
 license = "Apache-2.0"
 readme = "README.md"
-repository = "https://github.com/affinidi.com/affinidi-tdk"
+repository = "https://github.com/affinidi/affinidi-tdk"
 keywords = ["OpenAPI", "OpenAPI-Generator", "OidcVpAdapterBackend"]
 include = ["affinidi_tdk_login_configuration_client/py.typed"]
 

--- a/clients/python/wallets_client/pyproject.toml
+++ b/clients/python/wallets_client/pyproject.toml
@@ -5,7 +5,7 @@ description = "CloudWalletEssentials"
 authors = ["Affinidi <info@affinidi.com>"]
 license = "Apache-2.0"
 readme = "README.md"
-repository = "https://github.com/affinidi.com/affinidi-tdk"
+repository = "https://github.com/affinidi/affinidi-tdk"
 keywords = ["OpenAPI", "OpenAPI-Generator", "CloudWalletEssentials"]
 include = ["affinidi_tdk_wallets_client/py.typed"]
 

--- a/clients/typescript/credential-issuance-client/README.md
+++ b/clients/typescript/credential-issuance-client/README.md
@@ -2,7 +2,7 @@
 
 ### Service API Endpoints and Models
 
-Please check [the documentation for API Endpoints and Models](https://github.com/affinidi.com/affinidi-tdk/tree/main/clients/typescript/credential-issuance-client/docs/README.md) for more details.
+Please check [the documentation for API Endpoints and Models](https://github.com/affinidi/affinidi-tdk/tree/main/clients/typescript/credential-issuance-client/docs/README.md) for more details.
 
 ### Usage
 

--- a/clients/typescript/credential-issuance-client/package.json
+++ b/clients/typescript/credential-issuance-client/package.json
@@ -5,7 +5,7 @@
   "author": "Affinidi",
   "repository": {
     "type": "git",
-    "url": "https://github.com/affinidi.com/affinidi-tdk/tree/main/clients/typescript/credential-issuance-client"
+    "url": "https://github.com/affinidi/affinidi-tdk/tree/main/clients/typescript/credential-issuance-client"
   },
   "keywords": [
     "affinidi-tdk",

--- a/clients/typescript/credential-verification-client/README.md
+++ b/clients/typescript/credential-verification-client/README.md
@@ -2,7 +2,7 @@
 
 ### Service API Endpoints and Models
 
-Please check [the documentation for API Endpoints and Models](https://github.com/affinidi.com/affinidi-tdk/tree/main/clients/typescript/credential-verification-client/docs/README.md) for more details.
+Please check [the documentation for API Endpoints and Models](https://github.com/affinidi/affinidi-tdk/tree/main/clients/typescript/credential-verification-client/docs/README.md) for more details.
 
 ### Usage
 

--- a/clients/typescript/credential-verification-client/package.json
+++ b/clients/typescript/credential-verification-client/package.json
@@ -5,7 +5,7 @@
   "author": "Affinidi",
   "repository": {
     "type": "git",
-    "url": "https://github.com/affinidi.com/affinidi-tdk/tree/main/clients/typescript/credential-verification-client"
+    "url": "https://github.com/affinidi/affinidi-tdk/tree/main/clients/typescript/credential-verification-client"
   },
   "keywords": [
     "affinidi-tdk",

--- a/clients/typescript/iam-client/README.md
+++ b/clients/typescript/iam-client/README.md
@@ -2,7 +2,7 @@
 
 ### Service API Endpoints and Models
 
-Please check [the documentation for API Endpoints and Models](https://github.com/affinidi.com/affinidi-tdk/tree/main/clients/typescript/iam-client/docs/README.md) for more details.
+Please check [the documentation for API Endpoints and Models](https://github.com/affinidi/affinidi-tdk/tree/main/clients/typescript/iam-client/docs/README.md) for more details.
 
 ### Usage
 

--- a/clients/typescript/iam-client/package.json
+++ b/clients/typescript/iam-client/package.json
@@ -5,7 +5,7 @@
   "author": "Affinidi",
   "repository": {
     "type": "git",
-    "url": "https://github.com/affinidi.com/affinidi-tdk/tree/main/clients/typescript/iam-client"
+    "url": "https://github.com/affinidi/affinidi-tdk/tree/main/clients/typescript/iam-client"
   },
   "keywords": [
     "affinidi-tdk",

--- a/clients/typescript/iota-client/README.md
+++ b/clients/typescript/iota-client/README.md
@@ -2,7 +2,7 @@
 
 ### Service API Endpoints and Models
 
-Please check [the documentation for API Endpoints and Models](https://github.com/affinidi.com/affinidi-tdk/tree/main/clients/typescript/iota-client/docs/README.md) for more details.
+Please check [the documentation for API Endpoints and Models](https://github.com/affinidi/affinidi-tdk/tree/main/clients/typescript/iota-client/docs/README.md) for more details.
 
 ### Usage
 

--- a/clients/typescript/iota-client/package.json
+++ b/clients/typescript/iota-client/package.json
@@ -5,7 +5,7 @@
   "author": "Affinidi",
   "repository": {
     "type": "git",
-    "url": "https://github.com/affinidi.com/affinidi-tdk/tree/main/clients/typescript/iota-client"
+    "url": "https://github.com/affinidi/affinidi-tdk/tree/main/clients/typescript/iota-client"
   },
   "keywords": [
     "affinidi-tdk",

--- a/clients/typescript/login-configuration-client/README.md
+++ b/clients/typescript/login-configuration-client/README.md
@@ -2,7 +2,7 @@
 
 ### Service API Endpoints and Models
 
-Please check [the documentation for API Endpoints and Models](https://github.com/affinidi.com/affinidi-tdk/tree/main/clients/typescript/login-configuration-client/docs/README.md) for more details.
+Please check [the documentation for API Endpoints and Models](https://github.com/affinidi/affinidi-tdk/tree/main/clients/typescript/login-configuration-client/docs/README.md) for more details.
 
 ### Usage
 

--- a/clients/typescript/login-configuration-client/package.json
+++ b/clients/typescript/login-configuration-client/package.json
@@ -5,7 +5,7 @@
   "author": "Affinidi",
   "repository": {
     "type": "git",
-    "url": "https://github.com/affinidi.com/affinidi-tdk/tree/main/clients/typescript/login-configuration-client"
+    "url": "https://github.com/affinidi/affinidi-tdk/tree/main/clients/typescript/login-configuration-client"
   },
   "keywords": [
     "affinidi-tdk",

--- a/clients/typescript/wallets-client/README.md
+++ b/clients/typescript/wallets-client/README.md
@@ -2,7 +2,7 @@
 
 ### Service API Endpoints and Models
 
-Please check [the documentation for API Endpoints and Models](https://github.com/affinidi.com/affinidi-tdk/tree/main/clients/typescript/wallets-client/docs/README.md) for more details.
+Please check [the documentation for API Endpoints and Models](https://github.com/affinidi/affinidi-tdk/tree/main/clients/typescript/wallets-client/docs/README.md) for more details.
 
 ### Usage
 

--- a/clients/typescript/wallets-client/package.json
+++ b/clients/typescript/wallets-client/package.json
@@ -5,7 +5,7 @@
   "author": "Affinidi",
   "repository": {
     "type": "git",
-    "url": "https://github.com/affinidi.com/affinidi-tdk/tree/main/clients/typescript/wallets-client"
+    "url": "https://github.com/affinidi/affinidi-tdk/tree/main/clients/typescript/wallets-client"
   },
   "keywords": [
     "affinidi-tdk",


### PR DESCRIPTION
Numerous github links to files in affinidi repo were broken.
Changed https://github.com/affinidi.com/... to https://github.com/affinidi/...
All changed links were tested and confirmed to be valid.
