### PR TITLE
fix: release java & python on semantic release step

### DIFF
--- a/.github/workflows/nx-release.yaml
+++ b/.github/workflows/nx-release.yaml
@@ -6,16 +6,6 @@ on:
       - 'main'
 
 jobs:
-  security:
-    permissions:
-      contents: read
-      checks: read
-      statuses: read
-      security-events: write
-    uses: affinidi/pipeline-security/.github/workflows/security-scanners.yml@feat/check-inherit
-    with:
-      config-path: .github/labeler.yml
-    secrets: inherit
   release:
     concurrency: release
     runs-on: ubuntu-latest
@@ -24,7 +14,8 @@ jobs:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
       contents: read
-    needs: ['security']
+      issues: write
+      pull-requests: write
     steps:
       - name: Generate token from app token #https://github.com/tibdex/github-app-token
         id: generate_token
@@ -49,6 +40,37 @@ jobs:
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
           scope: '@affinidi-tdk'
+
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.x'
+
+      - name: install python tools
+        run: |
+          pip install twine
+          pip install poetry
+
+      - name: Mint pypi token
+        id: mint
+        uses: tschm/token-mint-action@v1.0.3
+
+      - name: Install gpg secret key for java Maven
+        run: |
+          echo "${{ secrets.MAVEN_GPG_SECRET_KEY }}" | gpg --batch --import
+          gpg --list-secret-keys --keyid-format LONG
+
+      - name: Set up JDK for deploy to Sonatype
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'corretto'
+          java-version: 21
+          server-id: central
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_CENTRAL_TOKEN
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: MAVEN_GPG_SECRET_KEY_PASSWORD
+
       - run: npm ci
       # Generate tag/changelog with semantic release
       # setting parallel higher than one might cause problems with locking git repo
@@ -57,6 +79,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+          MAVEN_CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
+          MAVEN_GPG_SECRET_KEY_PASSWORD: ${{ secrets.MAVEN_GPG_SECRET_KEY_PASSWORD }}
+         
   publish:
     concurrency: publish
     runs-on: ubuntu-latest
@@ -101,25 +127,6 @@ jobs:
         id: mint
         uses: tschm/token-mint-action@v1.0.3
 
-      - name: Set version for non-js client packages
-        run: npx nx run-many -t set-version
-
-      - name: Install gpg secret key for java Maven
-        run: |
-          echo "${{ secrets.MAVEN_GPG_SECRET_KEY }}" | gpg --batch --import
-          gpg --list-secret-keys --keyid-format LONG
-
-      - name: Set up JDK for deploy to Sonatype
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'corretto'
-          java-version: 21
-          server-id: central
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_CENTRAL_TOKEN
-          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
-          gpg-passphrase: MAVEN_GPG_SECRET_KEY_PASSWORD
-
       - name: build
         run: |
           npx nx run-many -t build --parallel=false
@@ -137,6 +144,3 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }} #publib-npm expects this
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
-          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
-          MAVEN_CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
-          MAVEN_GPG_SECRET_KEY_PASSWORD: ${{ secrets.MAVEN_GPG_SECRET_KEY_PASSWORD }}


### PR DESCRIPTION
* make sure requirements met to release java & python from semantic-release target
* remove old security pipeline
* jsii packages for python are still released from publish step, as well as any js package