### PR TITLE
feat: java packages publishing

### DIFF
--- a/packages/java/auth.provider/pom.xml
+++ b/packages/java/auth.provider/pom.xml
@@ -7,7 +7,7 @@
   <packaging>jar</packaging>
   <groupId>com.affinidi.tdk</groupId>
   <artifactId>auth.provider</artifactId>
-  <version>1.0</version>
+  <version>1.0.0</version>
   <name>auth.provider</name>
   <url>https://github.com/affinidi/affinidi-tdk</url>
   <licenses>
@@ -21,7 +21,7 @@
   <developers>
     <developer>
       <name>Affinidi</name>
-      <email>...</email>
+      <email>info@affinidi.com</email>
       <organization>Affinidi</organization>
       <organizationUrl>https://affinidi.com</organizationUrl>
     </developer>
@@ -36,7 +36,8 @@
     <junit-version>5.11.0</junit-version>
     <cdimascio-version>2.2.0</cdimascio-version>
     <jersey-version>3.1.7</jersey-version>
-    <affinidi-common-version>1.0</affinidi-common-version>
+    <!-- TODO: use modules resoluition for local developement-->
+    <affinidi-common-version>1.0.0</affinidi-common-version>
     <jsonwebtoken-version>0.12.6</jsonwebtoken-version>
     <mockito-version>3.12.4</mockito-version>
     <wiremock-version>3.10.0</wiremock-version>

--- a/packages/java/auth.provider/project.json
+++ b/packages/java/auth.provider/project.json
@@ -1,0 +1,40 @@
+{
+  "name": "@affinidi-tdk/auth-provider-java",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "{projectRoot}",
+  "projectType": "library",
+  "private": false,
+  "implicitDependencies": ["@affinidi-tdk/common-java"],
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "{projectRoot}",
+        "command": "mvn --no-transfer-progress --batch-mode clean package"
+      }
+    },
+    "semantic-release": {
+      "executor": "@theunderscorer/nx-semantic-release:semantic-release",
+      "options": {
+        "changelog": false,
+        "git": false,
+        "github": true,
+        "npm": false,
+        "repositoryUrl": "git@github.com:affinidi/affinidi-tdk.git",
+        "branches": ["main"],
+        "plugins": [
+          [
+            "@semantic-release/exec",
+            {
+              "execCwd": "{projectRoot}",
+              "prepareCmd": "mvn --no-transfer-progress --batch-mode versions:set -DnewVersion=${nextRelease.version}",
+              "publishCmd": "mvn --no-transfer-progress --batch-mode clean deploy",
+              "verifyConditionsCmd": "mvn --version"
+            }
+          ]
+        ]
+      }
+    }
+  },
+  "tags": ["lang:java", "kind:client"]
+}

--- a/packages/java/common/pom.xml
+++ b/packages/java/common/pom.xml
@@ -6,7 +6,7 @@
     <packaging>jar</packaging>
     <groupId>com.affinidi.tdk</groupId>
     <artifactId>common</artifactId>
-    <version>1.0</version>
+    <version>1.0.0</version>
     <name>common</name>
     <url>https://github.com/affinidi/affinidi-tdk</url>
     <licenses>
@@ -20,7 +20,7 @@
     <developers>
         <developer>
             <name>Affinidi</name>
-            <email>...</email>
+            <email>info@affinidi.com</email>
             <organization>Affinidi</organization>
             <organizationUrl>https://affinidi.com</organizationUrl>
         </developer>
@@ -117,6 +117,115 @@
                 <plugin>
                     <artifactId>maven-project-info-reports-plugin</artifactId>
                     <version>3.0.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>build-helper-maven-plugin</artifactId>
+                    <version>3.3.0</version>
+                    <executions>
+                        <execution>
+                            <id>add_sources</id>
+                            <phase>generate-sources</phase>
+                            <goals>
+                                <goal>add-source</goal>
+                            </goals>
+                            <configuration>
+                                <sources>
+                                    <source>src/main/java</source>
+                                </sources>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>add_test_sources</id>
+                            <phase>generate-test-sources</phase>
+                            <goals>
+                                <goal>add-test-source</goal>
+                            </goals>
+                            <configuration>
+                                <sources>
+                                    <source>src/test/java</source>
+                                </sources>
+                            </configuration>
+                        </execution>
+                    </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.4.1</version>
+                <configuration>
+                    <doclint>none</doclint>
+                    <source>1.8</source>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.2.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+             <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>0.6.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <publishingServerId>central</publishingServerId>
+                    <autoPublish>true</autoPublish>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.3.0</version>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                    <archive>
+                    </archive>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin> 
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-gpg-plugin</artifactId>
+                    <version>3.0.1</version>
+                    <executions>
+                        <execution>
+                            <id>sign-artifacts</id>
+                            <phase>verify</phase>
+                            <goals>
+                                <goal>sign</goal>
+                            </goals>
+                            <configuration>
+                                <arg>--pinentry-mode</arg>
+                                <arg>loopback</arg>
+                            </configuration>
+                        </execution>
+                    </executions>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/packages/java/common/project.json
+++ b/packages/java/common/project.json
@@ -1,0 +1,39 @@
+{
+  "name": "@affinidi-tdk/common-java",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "{projectRoot}",
+  "projectType": "library",
+  "private": false,
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "{projectRoot}",
+        "command": "mvn --no-transfer-progress --batch-mode clean package install"
+      }
+    },
+    "semantic-release": {
+      "executor": "@theunderscorer/nx-semantic-release:semantic-release",
+      "options": {
+        "changelog": false,
+        "git": false,
+        "github": true,
+        "npm": false,
+        "repositoryUrl": "git@github.com:affinidi/affinidi-tdk.git",
+        "branches": ["main"],
+        "plugins": [
+          [
+            "@semantic-release/exec",
+            {
+              "execCwd": "{projectRoot}",
+              "prepareCmd": "mvn --no-transfer-progress --batch-mode versions:set -DnewVersion=${nextRelease.version}",
+              "publishCmd": "mvn --no-transfer-progress --batch-mode clean deploy",
+              "verifyConditionsCmd": "mvn --version"
+            }
+          ]
+        ]
+      }
+    }
+  },
+  "tags": ["lang:java", "kind:client"]
+}


### PR DESCRIPTION
# What ?

* adds auth and common package to build pipeline
* adds releases & publish nx pipeline
* adds publishing config to maven pom xml's

# How ?

nx  `project.json` file is added, so this projects could be discovered by nx and their targets included when gh workflow calls them

semantic release sets version for both packages.

issue with auth provider being dependant on common package is handled by adding common package as implicit depenency in auth package as well as using `install` target

maven targets are called from nx targets