### PR TITLE
fix: python package publishing

### DIFF
--- a/.github/workflows/nx-release.yaml
+++ b/.github/workflows/nx-release.yaml
@@ -82,6 +82,9 @@ jobs:
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
           MAVEN_CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
           MAVEN_GPG_SECRET_KEY_PASSWORD: ${{ secrets.MAVEN_GPG_SECRET_KEY_PASSWORD }}
+          TWINE_USERNAME: '__token__'
+          TWINE_PASSWORD: ${{ steps.mint.outputs.api-token }}
+          POETRY_PYPI_TOKEN_PYPI: ${{ steps.mint.outputs.api-token }}
          
   publish:
     concurrency: publish


### PR DESCRIPTION
passing  oidc token was left out