### PR TITLE
fix: publish ts & jsii via semantic release

### DIFF
--- a/.github/workflows/nx-release.yaml
+++ b/.github/workflows/nx-release.yaml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
-      contents: read
+      contents: write
       issues: write
       pull-requests: write
     steps:
@@ -90,70 +90,4 @@ jobs:
           TWINE_USERNAME: '__token__'
           TWINE_PASSWORD: ${{ steps.mint.outputs.api-token }}
           POETRY_PYPI_TOKEN_PYPI: ${{ steps.mint.outputs.api-token }}
-         
-  publish:
-    concurrency: publish
-    runs-on: ubuntu-latest
-    environment: main
-    permissions:
-      # IMPORTANT: this permission is mandatory for trusted publishing
-      id-token: write
-      contents: read
-    needs: ['release']
-    steps:
-      - name: Generate token from app token #https://github.com/tibdex/github-app-token
-        id: generate_token
-        uses: tibdex/github-app-token@v2
-        with:
-          app_id: ${{ secrets.RELEASE_BOT_APP_ID }}
-          private_key: ${{ secrets.RELEASE_BOT_PKEY }}
-
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: ${{ github.ref }}
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 18
-          cache: 'npm'
-          registry-url: 'https://registry.npmjs.org'
-          scope: '@affinidi-tdk'
-      - run: npm ci
-
-      - name: Set up Python
-        uses: actions/setup-python@v3
-        with:
-          python-version: '3.x'
-      
-      - name: Set up Dart
-        uses: dart-lang/setup-dart@v1
-        with:
-          sdk: 3.6.0
-
-      - name: install python tools
-        run: |
-          pip install twine
-          pip install poetry
-
-      - name: Mint pypi token
-        id: mint
-        uses: tschm/token-mint-action@v1.0.3
-
-      - name: build
-        run: |
-          npx nx run-many -t build --parallel=false
-      - name: package
-        run: |
-          npx nx run-many -t package
-      # Publish to npm,pypi  with new nx release publish functionality
-      - run: |
-          npx nx release publish --verbose
-        name: publish
-        env:
-          TWINE_USERNAME: '__token__'
-          TWINE_PASSWORD: ${{ steps.mint.outputs.api-token }}
-          POETRY_PYPI_TOKEN_PYPI: ${{ steps.mint.outputs.api-token }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }} #publib-npm expects this
-          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/libs/iota-browser/package.json
+++ b/libs/iota-browser/package.json
@@ -3,6 +3,11 @@
   "version": "1.21.0",
   "description": "Browser module to fetch data through Affinidi Iota Framework",
   "author": "Affinidi",
+  "private": false,
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/affinidi/affinidi-tdk"

--- a/libs/iota-browser/project.json
+++ b/libs/iota-browser/project.json
@@ -23,31 +23,23 @@
     "lint": {
       "executor": "@nx/eslint:lint"
     },
-    "nx-release-publish": {
-      "executor": "nx:run-commands",
-      "options": {
-        "cwd": "libs/iota-browser",
-        "command": "npm run publib-npm"
-      },
-      "dependsOn": [
-        {
-          "target": "build"
-        }
-      ]
-    },
     "semantic-release": {
       "executor": "@theunderscorer/nx-semantic-release:semantic-release",
+      "dependsOn": ["build"],
       "options": {
         "changelog": true,
         "github": true,
-        "npm": true,
+        "npm": false,
         "repositoryUrl": "git@github.com:affinidi/affinidi-tdk.git",
         "branches": ["main"],
         "plugins": [
           [
-            "@semantic-release/npm",
+            "@semantic-release/exec",
             {
-              "npmPublish": true
+              "execCwd": "{projectRoot}",
+              "prepareCmd": "npm version ${nextRelease.version}",
+              "publishCmd": "npm run publish-npm",
+              "verifyConditionsCmd": "npm version"
             }
           ]
         ]

--- a/libs/iota-browser/project.json
+++ b/libs/iota-browser/project.json
@@ -29,6 +29,7 @@
       "options": {
         "changelog": true,
         "github": true,
+        "git": true,
         "npm": false,
         "repositoryUrl": "git@github.com:affinidi/affinidi-tdk.git",
         "branches": ["main"],

--- a/libs/iota-core/package.json
+++ b/libs/iota-core/package.json
@@ -7,6 +7,11 @@
     "type": "git",
     "url": "https://github.com/affinidi/affinidi-tdk"
   },
+  "private": false,
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
   "keywords": [
     "affinidi-tdk",
     "affinidi-iota-framework",

--- a/libs/iota-core/project.json
+++ b/libs/iota-core/project.json
@@ -3,7 +3,6 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "libs/iota-core",
   "projectType": "library",
-  "private": false,
   "targets": {
     "install-node-modules": {
       "executor": "nx:run-commands",
@@ -30,26 +29,23 @@
       "dependsOn": ["build"],
       "outputs": ["{projectRoot}/dist/"]
     },
-    "nx-release-publish": {
-      "executor": "nx:run-commands",
-      "options": {
-        "cwd": "{projectRoot}",
-        "commands": ["npm run publish-pypi", "npm run publish-npm"]
-      }
-    },
     "semantic-release": {
       "executor": "@theunderscorer/nx-semantic-release:semantic-release",
+      "dependsOn": ["package"],
       "options": {
         "changelog": true,
         "github": true,
-        "npm": true,
+        "npm": false,
         "repositoryUrl": "git@github.com:affinidi/affinidi-tdk.git",
         "branches": ["main"],
         "plugins": [
           [
-            "@semantic-release/npm",
+            "@semantic-release/exec",
             {
-              "npmPublish": true
+              "execCwd": "{projectRoot}",
+              "prepareCmd": "npm version ${nextRelease.version}",
+              "publishCmd": "npm run publish-pypi && npm run publish-npm",
+              "verifyConditionsCmd": "npm version"
             }
           ]
         ]

--- a/libs/iota-core/project.json
+++ b/libs/iota-core/project.json
@@ -35,6 +35,7 @@
       "options": {
         "changelog": true,
         "github": true,
+        "git": true,
         "npm": false,
         "repositoryUrl": "git@github.com:affinidi/affinidi-tdk.git",
         "branches": ["main"],

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
     "build": "nx run-many --verbose --target=build",
     "create:sample": "./scripts/create-sample.sh"
   },
-  "private": true,
+  "private": "true",
+  "publishConfig": {
+    "access": "restricted"
+  },
   "dependencies": {
     "tslib": "^2.6.2"
   },

--- a/packages/jsii/auth-provider/package.json
+++ b/packages/jsii/auth-provider/package.json
@@ -7,6 +7,11 @@
     "type": "git",
     "url": "https://github.com/affinidi/affinidi-tdk"
   },
+  "private": false,
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
   "keywords": [
     "affinidi-tdk",
     "identity",

--- a/packages/jsii/auth-provider/project.json
+++ b/packages/jsii/auth-provider/project.json
@@ -37,18 +37,20 @@
       "executor": "@theunderscorer/nx-semantic-release:semantic-release",
       "dependsOn": ["package"],
       "options": {
-        "changelog": false,
-        "git": false,
-        "github": false,
-        "npm": true,
+        "changelog": true,
+        "github": true,
+        "git": true,
+        "npm": false,
         "repositoryUrl": "git@github.com:affinidi/affinidi-tdk.git",
         "branches": ["main"],
         "plugins": [
           [
-            "@semantic-release/npm",
+            "@semantic-release/exec",
             {
-              "npmPublish": true,
-              "pkgRoot": "{projectRoot}"
+              "execCwd": "{projectRoot}",
+              "prepareCmd": "npm version ${nextRelease.version}",
+              "publishCmd": "npm run publish-pypi && npm run publish-npm",
+              "verifyConditionsCmd": "npm version"
             }
           ]
         ]

--- a/packages/jsii/auth-provider/project.json
+++ b/packages/jsii/auth-provider/project.json
@@ -1,7 +1,7 @@
 {
   "name": "@affinidi-tdk/auth-provider",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
-  "sourceRoot": "packages/auth-provider",
+  "sourceRoot": "packages/jsii/auth-provider",
   "projectType": "library",
   "private": false,
   "targets": {
@@ -33,18 +33,13 @@
     "lint": {
       "executor": "@nx/eslint:lint"
     },
-    "nx-release-publish": {
-      "executor": "nx:run-commands",
-      "options": {
-        "cwd": "{projectRoot}",
-        "commands": ["npm run publish-pypi", "npm run publish-npm"]
-      }
-    },
     "semantic-release": {
       "executor": "@theunderscorer/nx-semantic-release:semantic-release",
+      "dependsOn": ["package"],
       "options": {
-        "changelog": true,
-        "github": true,
+        "changelog": false,
+        "git": false,
+        "github": false,
         "npm": true,
         "repositoryUrl": "git@github.com:affinidi/affinidi-tdk.git",
         "branches": ["main"],
@@ -52,7 +47,8 @@
           [
             "@semantic-release/npm",
             {
-              "npmPublish": true
+              "npmPublish": true,
+              "pkgRoot": "{projectRoot}"
             }
           ]
         ]

--- a/packages/jsii/common/package.json
+++ b/packages/jsii/common/package.json
@@ -7,6 +7,11 @@
     "type": "git",
     "url": "https://github.com/affinidi/affinidi-tdk"
   },
+  "private": false,
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
   "keywords": [
     "affinidi-tdk",
     "identity",

--- a/packages/jsii/common/project.json
+++ b/packages/jsii/common/project.json
@@ -38,7 +38,7 @@
         "git": false,
         "github": false,
         "npm": true,
-        "repositoryUrl": "git@github.com:maratsh/affinidi-tdk.git",
+        "repositoryUrl": "git@github.com:affinidi/affinidi-tdk.git",
         "branches": ["main"],
         "plugins": [
           [

--- a/packages/jsii/common/project.json
+++ b/packages/jsii/common/project.json
@@ -34,11 +34,11 @@
       "executor": "@theunderscorer/nx-semantic-release:semantic-release",
       "dependsOn": ["package"],
       "options": {
-        "changelog": false,
-        "git": false,
-        "github": false,
-        "npm": true,
-        "repositoryUrl": "git@github.com:affinidi/affinidi-tdk.git",
+        "changelog": true,
+        "git": true,
+        "github": true,
+        "npm": false,
+        "repositoryUrl": "git@github.com:maratsh/affinidi-tdk.git",
         "branches": ["main"],
         "plugins": [
           [

--- a/packages/jsii/common/project.json
+++ b/packages/jsii/common/project.json
@@ -1,7 +1,7 @@
 {
   "name": "@affinidi-tdk/common",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
-  "sourceRoot": "packages/common",
+  "sourceRoot": "packages/jsii/common",
   "projectType": "library",
   "private": false,
   "targets": {
@@ -30,26 +30,22 @@
       "dependsOn": ["build"],
       "outputs": ["{projectRoot}/dist/"]
     },
-    "nx-release-publish": {
-      "executor": "nx:run-commands",
-      "options": {
-        "cwd": "{projectRoot}",
-        "commands": ["npm run publish-pypi", "npm run publish-npm"]
-      }
-    },
     "semantic-release": {
       "executor": "@theunderscorer/nx-semantic-release:semantic-release",
+      "dependsOn": ["package"],
       "options": {
-        "changelog": true,
-        "github": true,
+        "changelog": false,
+        "git": false,
+        "github": false,
         "npm": true,
-        "repositoryUrl": "git@github.com:affinidi/affinidi-tdk.git",
+        "repositoryUrl": "git@github.com:maratsh/affinidi-tdk.git",
         "branches": ["main"],
         "plugins": [
           [
             "@semantic-release/npm",
             {
-              "npmPublish": true
+              "npmPublish": true,
+              "pkgRoot": "{projectRoot}"
             }
           ]
         ]

--- a/packages/jsii/common/project.json
+++ b/packages/jsii/common/project.json
@@ -38,7 +38,7 @@
         "git": true,
         "github": true,
         "npm": false,
-        "repositoryUrl": "git@github.com:maratsh/affinidi-tdk.git",
+        "repositoryUrl": "git@github.com:affinidi/affinidi-tdk.git",
         "branches": ["main"],
         "plugins": [
           [


### PR DESCRIPTION
# allows publishing directly via semantic release

* makes sure packages are recognised as  public
* semantic release exec plugin to release
* aligned to clients
* fixed issue with path to nx projects in new jsii folder