### PR TITLE
feat: add dart publishing on tags

### DIFF
--- a/.github/workflows/publish-dart.yaml
+++ b/.github/workflows/publish-dart.yaml
@@ -1,0 +1,41 @@
+name: Publish Affected Dart Projects
+
+on:
+  push:
+    tags:
+      - '*dart-v*'  
+
+jobs:
+  publish:
+    permissions:
+      id-token: write
+    environment: main
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+
+      - name: Set up Dart
+        uses: dart-lang/setup-dart@v1
+        with:
+          sdk: 3.6.0
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Extract Project Name from Tag
+        run: echo "PROJECT_NAME=$(echo ${GITHUB_REF#refs/tags/} | cut -d'-' -f1)" >> $GITHUB_ENV
+
+      - name: Extract Release Version from Tag
+        run: echo "RELEASE_VERSION=$(echo ${GITHUB_REF#refs/tags/} | cut -d'-' -f2 | cut -c2-)" >> $GITHUB_ENV
+
+      - name: Publish Tagged Project
+        run: npx nx run ${{ env.PROJECT_NAME }}:publish --args="-releaseVersion=${env.RELEASE_VERSION}"

--- a/package-lock.json
+++ b/package-lock.json
@@ -290,7 +290,7 @@
     },
     "libs/iota-browser": {
       "name": "@affinidi-tdk/iota-browser",
-      "version": "1.21.0",
+      "version": "1.21.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@affinidi-tdk/common": "^1.1.1",
@@ -459,7 +459,7 @@
     },
     "libs/iota-core": {
       "name": "@affinidi-tdk/iota-core",
-      "version": "1.22.1",
+      "version": "1.22.2",
       "bundleDependencies": [
         "@affinidi-tdk/common",
         "@affinidi-tdk/iota-client",

--- a/packages/dart/auth_provider/project.json
+++ b/packages/dart/auth_provider/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@affinidi-tdk/affinidi_tdk_auth_provider_dart",
+  "name": "affinidi_tdk_auth_provider_dart",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "{projectRoot}",
   "projectType": "library",
@@ -26,12 +26,22 @@
             "@semantic-release/exec",
             {
               "execCwd": "{projectRoot}",
-              "prepareCmd": "sed -i \"s|^version: .*|version: ${nextRelease.version}|\" pubspec.yaml",
-              "publishCmd": "dart pub publish --force",
               "verifyConditionsCmd": "dart --version"
             }
           ]
         ]
+      }
+    },
+    "publish": {
+      "executor": "nx:run-commands",
+      "dependsOn": ["build"],
+      "options": {
+        "cwd": "{projectRoot}",
+        "commands": [
+          "sed -i \"s|^version: .*|version: {args.releaseVersion}|\" pubspec.yaml",
+          "dart pub publish --force"
+        ],
+        "parrallel": false
       }
     }
   },

--- a/packages/dart/auth_provider/project.json
+++ b/packages/dart/auth_provider/project.json
@@ -20,16 +20,7 @@
         "github": true,
         "npm": false,
         "repositoryUrl": "git@github.com:affinidi/affinidi-tdk.git",
-        "branches": ["main"],
-        "plugins": [
-          [
-            "@semantic-release/exec",
-            {
-              "execCwd": "{projectRoot}",
-              "verifyConditionsCmd": "dart --version"
-            }
-          ]
-        ]
+        "branches": ["main"]
       }
     },
     "publish": {

--- a/packages/dart/common/project.json
+++ b/packages/dart/common/project.json
@@ -20,16 +20,7 @@
         "github": true,
         "npm": false,
         "repositoryUrl": "git@github.com:affinidi/affinidi-tdk.git",
-        "branches": ["main"],
-        "plugins": [
-          [
-            "@semantic-release/exec",
-            {
-              "execCwd": "{projectRoot}",
-              "verifyConditionsCmd": "dart --version"
-            }
-          ]
-        ]
+        "branches": ["main"]
       }
     },
     "publish": {

--- a/packages/dart/common/project.json
+++ b/packages/dart/common/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@affinidi-tdk/affinidi_tdk_common_dart",
+  "name": "affinidi_tdk_common_dart",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "{projectRoot}",
   "projectType": "library",
@@ -26,12 +26,22 @@
             "@semantic-release/exec",
             {
               "execCwd": "{projectRoot}",
-              "prepareCmd": "sed -i \"s|^version: .*|version: ${nextRelease.version}|\" pubspec.yaml",
-              "publishCmd": "dart pub publish --force",
               "verifyConditionsCmd": "dart --version"
             }
           ]
         ]
+      }
+    },
+    "publish": {
+      "executor": "nx:run-commands",
+      "dependsOn": ["build"],
+      "options": {
+        "cwd": "{projectRoot}",
+        "commands": [
+          "sed -i \"s|^version: .*|version: {args.releaseVersion}|\" pubspec.yaml",
+          "dart pub publish --force"
+        ],
+        "parrallel": false
       }
     }
   },

--- a/packages/dart/consumer_auth_provider/project.json
+++ b/packages/dart/consumer_auth_provider/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@affinidi-tdk/affinidi_tdk_consumer_auth_provider_dart",
+  "name": "affinidi_tdk_consumer_auth_provider_dart",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "{projectRoot}",
   "projectType": "library",
@@ -26,12 +26,22 @@
             "@semantic-release/exec",
             {
               "execCwd": "{projectRoot}",
-              "prepareCmd": "sed -i \"s|^version: .*|version: ${nextRelease.version}|\" pubspec.yaml",
-              "publishCmd": "dart pub publish --force",
               "verifyConditionsCmd": "dart --version"
             }
           ]
         ]
+      }
+    },
+    "publish": {
+      "executor": "nx:run-commands",
+      "dependsOn": ["build"],
+      "options": {
+        "cwd": "{projectRoot}",
+        "commands": [
+          "sed -i \"s|^version: .*|version: {args.releaseVersion}|\" pubspec.yaml",
+          "dart pub publish --force"
+        ],
+        "parrallel": false
       }
     }
   },

--- a/packages/dart/consumer_auth_provider/project.json
+++ b/packages/dart/consumer_auth_provider/project.json
@@ -20,16 +20,7 @@
         "github": true,
         "npm": false,
         "repositoryUrl": "git@github.com:affinidi/affinidi-tdk.git",
-        "branches": ["main"],
-        "plugins": [
-          [
-            "@semantic-release/exec",
-            {
-              "execCwd": "{projectRoot}",
-              "verifyConditionsCmd": "dart --version"
-            }
-          ]
-        ]
+        "branches": ["main"]
       }
     },
     "publish": {

--- a/packages/dart/cryptography/project.json
+++ b/packages/dart/cryptography/project.json
@@ -20,16 +20,7 @@
         "github": true,
         "npm": false,
         "repositoryUrl": "git@github.com:affinidi/affinidi-tdk.git",
-        "branches": ["main"],
-        "plugins": [
-          [
-            "@semantic-release/exec",
-            {
-              "execCwd": "{projectRoot}",
-              "verifyConditionsCmd": "dart --version"
-            }
-          ]
-        ]
+        "branches": ["main"]
       }
     },
     "publish": {

--- a/packages/dart/cryptography/project.json
+++ b/packages/dart/cryptography/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@affinidi-tdk/affinidi_tdk_cryptography_dart",
+  "name": "affinidi_tdk_cryptography_dart",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "{projectRoot}",
   "projectType": "library",
@@ -26,12 +26,22 @@
             "@semantic-release/exec",
             {
               "execCwd": "{projectRoot}",
-              "prepareCmd": "sed -i \"s|^version: .*|version: ${nextRelease.version}|\" pubspec.yaml",
-              "publishCmd": "dart pub publish --force",
               "verifyConditionsCmd": "dart --version"
             }
           ]
         ]
+      }
+    },
+    "publish": {
+      "executor": "nx:run-commands",
+      "dependsOn": ["build"],
+      "options": {
+        "cwd": "{projectRoot}",
+        "commands": [
+          "sed -i \"s|^version: .*|version: {args.releaseVersion}|\" pubspec.yaml",
+          "dart pub publish --force"
+        ],
+        "parrallel": false
       }
     }
   },


### PR DESCRIPTION
Because pub.dev only allows publishing from tags we need a separate workflow to do the publishing. Also tag pattern is pretty strict, nx project naming should be changed accordingly. Generated clients will follow once packages are done.