### PR TITLE
ci: release only affected projects

### DIFF
--- a/.github/workflows/nx-release.yaml
+++ b/.github/workflows/nx-release.yaml
@@ -79,7 +79,7 @@ jobs:
       - run: npm ci
       # Generate tag/changelog with semantic release
       # setting parallel higher than one might cause problems with locking git repo
-      - run: npx nx run-many  -t semantic-release --parallel=false
+      - run: npx nx affected  -t semantic-release --parallel=false --base=$BASE_SHA --head=HEAD
         name: semantic release
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
@@ -91,3 +91,4 @@ jobs:
           TWINE_PASSWORD: ${{ steps.mint.outputs.api-token }}
           POETRY_PYPI_TOKEN_PYPI: ${{ steps.mint.outputs.api-token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          BASE_SHA: ${{ github.event.before }}


### PR DESCRIPTION
# What?

Release only projects affected by last changes

# Why?

releasing 40 packages is becoming slow and instable

# How?

We extract commit before push from github push event https://docs.github.com/en/webhooks/webhook-events-and-payloads#push