### PR TITLE
fix: fetch correct environment on compile

### DIFF
--- a/packages/dart/common/lib/src/environment.dart
+++ b/packages/dart/common/lib/src/environment.dart
@@ -89,7 +89,6 @@ class Environment {
   /// Fetches the current environment based on the provided environment variable.
   static Environment fetchEnvironment() {
     final envValue = const String.fromEnvironment(enviromentVariableName);
-
     final environmentType = EnvironmentType.values.firstWhere(
       (e) => e.value == envValue,
       orElse: () => EnvironmentType.prod,

--- a/packages/dart/common/lib/src/environment.dart
+++ b/packages/dart/common/lib/src/environment.dart
@@ -88,15 +88,7 @@ class Environment {
 
   /// Fetches the current environment based on the provided environment variable.
   static Environment fetchEnvironment() {
-    const compileTimeEnv = String.fromEnvironment(enviromentVariableName);
-    final String envValue;
-    if (compileTimeEnv.isEmpty) {
-      // just in time environment (dart run)
-      envValue = String.fromEnvironment(enviromentVariableName);
-    } else {
-      // compile time environment (dart compile)
-      envValue = compileTimeEnv;
-    }
+    final envValue = const String.fromEnvironment(enviromentVariableName);
 
     final environmentType = EnvironmentType.values.firstWhere(
       (e) => e.value == envValue,

--- a/packages/dart/common/lib/src/environment.dart
+++ b/packages/dart/common/lib/src/environment.dart
@@ -88,7 +88,16 @@ class Environment {
 
   /// Fetches the current environment based on the provided environment variable.
   static Environment fetchEnvironment() {
-    final envValue = String.fromEnvironment(enviromentVariableName);
+    const compileTimeEnv = String.fromEnvironment(enviromentVariableName);
+    final String envValue;
+    if (compileTimeEnv.isEmpty) {
+      // just in time environment (dart run)
+      envValue = String.fromEnvironment(enviromentVariableName);
+    } else {
+      // compile time environment (dart compile)
+      envValue = compileTimeEnv;
+    }
+
     final environmentType = EnvironmentType.values.firstWhere(
       (e) => e.value == envValue,
       orElse: () => EnvironmentType.prod,


### PR DESCRIPTION
To ensure that String.fromEnvironment("") works with compiled code we need to define it as a const.

Note that with this change it is now important to specify the file name when running just in time: 

`dart run --define=AFFINIDI_TDK_ENVIRONMENT=dev bin/vfs_access_control.dart`
