### PR TITLE
fix: dart publishing

### DIFF
--- a/.github/workflows/publish-dart.yaml
+++ b/.github/workflows/publish-dart.yaml
@@ -1,9 +1,10 @@
-name: Publish Affected Dart Projects
+name: publish dart
 
 on:
   push:
     tags:
       - '**dart-v**'  
+  workflow_dispatch:
 
 jobs:
   publish:

--- a/packages/dart/auth_provider/project.json
+++ b/packages/dart/auth_provider/project.json
@@ -34,8 +34,8 @@
     "semantic-release": {
       "executor": "@theunderscorer/nx-semantic-release:semantic-release",
       "options": {
-        "changelog": true,
-        "git": true,
+        "changelog": false,
+        "git": false,
         "github": true,
         "npm": false,
         "repositoryUrl": "git@github.com:affinidi/affinidi-tdk.git",

--- a/packages/dart/common/project.json
+++ b/packages/dart/common/project.json
@@ -34,8 +34,8 @@
     "semantic-release": {
       "executor": "@theunderscorer/nx-semantic-release:semantic-release",
       "options": {
-        "changelog": true,
-        "git": true,
+        "changelog": false,
+        "git": false,
         "github": true,
         "npm": false,
         "repositoryUrl": "git@github.com:affinidi/affinidi-tdk.git",

--- a/packages/dart/consumer_auth_provider/project.json
+++ b/packages/dart/consumer_auth_provider/project.json
@@ -34,8 +34,8 @@
     "semantic-release": {
       "executor": "@theunderscorer/nx-semantic-release:semantic-release",
       "options": {
-        "changelog": true,
-        "git": true,
+        "changelog": false,
+        "git": false,
         "github": true,
         "npm": false,
         "repositoryUrl": "git@github.com:affinidi/affinidi-tdk.git",

--- a/packages/dart/cryptography/project.json
+++ b/packages/dart/cryptography/project.json
@@ -34,8 +34,8 @@
     "semantic-release": {
       "executor": "@theunderscorer/nx-semantic-release:semantic-release",
       "options": {
-        "changelog": true,
-        "git": true,
+        "changelog": false,
+        "git": false,
         "github": true,
         "npm": false,
         "repositoryUrl": "git@github.com:affinidi/affinidi-tdk.git",


### PR DESCRIPTION
* allows manually start dart publishing
* disable git plugin for now to unblock automatic releases