### PR TITLE
fix: clear memoized profile data on profile deletion

### DIFF
--- a/libs/dart/vault_storages/lib/src/profiles/vfs_profile_repository.dart
+++ b/libs/dart/vault_storages/lib/src/profiles/vfs_profile_repository.dart
@@ -254,6 +254,8 @@ class VfsProfileRepository implements ProfileRepository {
       kek: Uint8List(2),
     );
     await accountDataManager.deleteAccount(accountIndex: profile.accountIndex);
+
+    _clearMemoizedProfileData(profile.accountIndex);
   }
 
   @override
@@ -281,6 +283,12 @@ class VfsProfileRepository implements ProfileRepository {
   }
 
   final _dataManagers = <String, VaultDataManagerService>{};
+
+  /// Deletes any memoized data associated to the accountIndex when a profile is deleted
+  void _clearMemoizedProfileData(int accountIndex) {
+    _didSigners.remove('$accountIndex');
+    _dataManagers.remove('$accountIndex');
+  }
 
   /// Memoize dataManagerService based on the walletKeyId
   Future<VaultDataManagerService> _memoizedDataManagerService({


### PR DESCRIPTION
* clears memoized data associated to profiles when deleting profile to prevent reuse.
* clears credentials on existing profiles when resetting examples
* clears subfolders on existing profiles when resetting examples