### PR TITLE
chore: request credential offer issuer metadata before the offer

### DIFF
--- a/libs/dart/claim_verifiable_credential/lib/src/exceptions/tdk_exception_type.dart
+++ b/libs/dart/claim_verifiable_credential/lib/src/exceptions/tdk_exception_type.dart
@@ -1,38 +1,38 @@
 /// Enum representing different types of exceptions that can occur in this package.
 ///
-/// - [credentialOfferExpired] - indicates that the credential offer has expired.
-/// - [invalidCredentialRequest] - represents an invalid credential request error.
 /// - [credentialOfferClaimed] - indicates that the credential offer has already been claimed.
-/// - [invalidCredentialProof] - indicates that the proof in the credential request is invalid.
 /// - [expiredToken] - indicates that the access token has expired.
+/// - [credentialOfferExpired] - indicates that the credential offer has expired.
 /// - [failedToClaimCredential] - represents a failure to claim a credential.
 /// - [failedToLoadCredentialOffer] - indicates a failure to load the credential offer.
 /// - [failedToLoadIssuerMetadata] - represents a failure to load issuer metadata.
-/// - [missingUri] - indicates that a required URI is missing.
-/// - [unmatchedTxCode] - represents an unmatched transaction code error.
+/// - [invalidCredentialProof] - indicates that the proof in the credential request is invalid.
+/// - [invalidCredentialRequest] - represents an invalid credential request error.
 /// - [invalidParameter] - indicates an invalid parameter error.
-/// - [serverError] - represents a server-side error.
+/// - [missingUri] - indicates that a required URI is missing.
 /// - [networkError] - indicates a network-related error.
 /// - [other] - represents any other unspecified error.
+/// - [serverError] - represents a server-side error.
+/// - [unmatchedTxCode] - represents an unmatched transaction code error.
 ///
 /// Each exception type has the following properties:
 /// - [jsonValue] - string representation of the exception type used for JSON serialization.
 /// - [code] - string code that uniquely identifies the exception type.
 enum TdkExceptionType {
-  /// Indicates that the credential offer has expired.
-  credentialOfferExpired(
-      'CredentialOfferExpiredError', 'credential_offer_expired'),
-
-  /// Represents an invalid credential request error.
-  invalidCredentialRequest(
-      'InvalidCredentialRequestError', 'invalid_credential_request'),
-
   /// Indicates that the credential offer has already been claimed.
   credentialOfferClaimed(
       'CredentialOfferClaimedError', 'credential_offer_claimed'),
 
+  /// Indicates that the credential offer has expired.
+  credentialOfferExpired(
+      'CredentialOfferExpiredError', 'credential_offer_expired'),
+
   /// Indicates the proof in the credential request is invalid.
   invalidCredentialProof('InvalidCredentialProof', 'invalid_credential_proof'),
+
+  /// Represents an invalid credential request error.
+  invalidCredentialRequest(
+      'InvalidCredentialRequestError', 'invalid_credential_request'),
 
   /// Indicates that the access token has expired.
   expiredToken('ExpiredTokenError', 'expired_token'),
@@ -49,23 +49,23 @@ enum TdkExceptionType {
   failedToLoadIssuerMetadata(
       'FailedToLoadIssuerMetadata', 'failed_to_load_issuer_metadata'),
 
-  /// Indicates that a required URI is missing.
-  missingUri('MissingUri', 'missing_uri'),
-
-  /// Represents an unmatched transaction code error.
-  unmatchedTxCode('UnmatchedTxCode', 'unmatched_tx_code'),
-
   /// Indicates an invalid parameter error.
   invalidParameter('InvalidParameterError', 'invalid_parameter'),
 
-  /// Represents a server-side error.
-  serverError('serverError', 'server_error'),
+  /// Indicates that a required URI is missing.
+  missingUri('MissingUri', 'missing_uri'),
 
   /// Indicates a network-related error.
   networkError('NetworkError', 'network_error'),
 
   /// Represents unspecified error.
   other('Other', 'other'),
+
+  /// Represents a server-side error.
+  serverError('serverError', 'server_error'),
+
+  /// Represents an unmatched transaction code error.
+  unmatchedTxCode('UnmatchedTxCode', 'unmatched_tx_code'),
   ;
 
   const TdkExceptionType(this.jsonValue, this.code);

--- a/libs/dart/claim_verifiable_credential/lib/src/oid4vci_claim_verifiable_credential.dart
+++ b/libs/dart/claim_verifiable_credential/lib/src/oid4vci_claim_verifiable_credential.dart
@@ -114,14 +114,15 @@ class OID4VCIClaimVerifiableCredentialService
     }
 
     try {
-      final credentialOfferResponse =
-          await _getCredentialsOfferResponse(credentialOfferUri);
-      final credentialOffer = OID4VCICredentialOffer.fromJson(
-          credentialOfferResponse.data as Map<String, dynamic>);
       final issuerMetadataResponse = await _claimVerifiableCredentialApiService
           .getIssuerMetadata(offerUri: credentialOfferUri);
       final issuerMetadata = OID4VCIIssuerMetadata.fromJson(
           issuerMetadataResponse.data as Map<String, dynamic>);
+
+      final credentialOfferResponse =
+          await _getCredentialsOfferResponse(credentialOfferUri);
+      final credentialOffer = OID4VCICredentialOffer.fromJson(
+          credentialOfferResponse.data as Map<String, dynamic>);
 
       _logger.info('Completed loading credential offer',
           component: _componentName);


### PR DESCRIPTION
Inverted order of network requests.
It now first checks for issuer metadata and if this can be parsed continues to make a credential offer request.
If the metadata retrieved does not match the expected data format, it will throw an error with code failedToLoadIssuerMetadata