### PR TITLE
chore: add way to reuse seed

### DIFF
--- a/libs/dart/vault_flutter_utils/example/flutter_secure_storage/lib/services/vault_service.dart
+++ b/libs/dart/vault_flutter_utils/example/flutter_secure_storage/lib/services/vault_service.dart
@@ -1,5 +1,6 @@
 import 'package:affinidi_tdk_vault/affinidi_tdk_vault.dart';
 import 'package:affinidi_tdk_vault_storages/affinidi_tdk_vault_storages.dart';
+import 'package:base_codecs/base_codecs.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:affinidi_tdk_vault_flutter_utils/vault_flutter_utils.dart';
 
@@ -18,6 +19,14 @@ class VaultService extends _$VaultService {
     });
 
     return VaultServiceState();
+  }
+
+  Future<void> clearKeyStorage() async {
+    final keyStorage = _getkeyStorage();
+    await keyStorage.clear();
+    print('Vault key storage cleared');
+
+    _makeSeedIfNeeded(keyStorage);
   }
 
   Future<void> _create() async {
@@ -42,10 +51,22 @@ class VaultService extends _$VaultService {
 
   Future<void> _makeSeedIfNeeded(FlutterSecureVaultStore vaultStore) async {
     final existingSeed = await vaultStore.getSeed();
+    print(
+      'Existing seed: ${existingSeed != null ? hexEncode(existingSeed) : 'null'}',
+    );
     if (existingSeed == null) {
-      final seed = vaultStore.getRandomSeed();
+      final seed = hexDecode(
+        'abc123', // Replace with the seed associated to the whitelisted Vault
+      );
+      // final seed = vaultStore.getRandomSeed();
+      // final seed = Uint8List.fromList(List.generate(32, (idx) => idx + 1));
+      print('Generated seed: ${hexEncode(seed)}');
       await vaultStore.setSeed(seed);
     }
+  }
+
+  FlutterSecureVaultStore _getkeyStorage() {
+    return ref.read(_keyStorageProvider);
   }
 }
 

--- a/libs/dart/vault_flutter_utils/example/flutter_secure_storage/pubspec.yaml
+++ b/libs/dart/vault_flutter_utils/example/flutter_secure_storage/pubspec.yaml
@@ -43,6 +43,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  base_codecs: ^1.0.1
 
 dev_dependencies:
   build_runner: ^2.4.4


### PR DESCRIPTION
1. Make sure to call `clearKeyStorage()` to clear existing storage
2. It will automatically re-call `_makeSeedIfNeeded()` that generates the seed
3. However the seed here is hardcoded, edit [this](https://github.com/affinidi/affinidi-tdk/compare/chore/reuse-seed?expand=1#diff-070e77b534f03e1d2fbb9026f51f4aae5c02836a20e1f29177858415c8757bbfR59) using the seed associated to the whitelisted DID