### PR TITLE
test: skip test for CIS until backend is fixed

### DIFF
--- a/tests/integration/dart/test/credential_issuance_client_test.dart
+++ b/tests/integration/dart/test/credential_issuance_client_test.dart
@@ -228,7 +228,7 @@ void main() {
         expect(data, isNotNull);
         expect(data?.credentials, isNotNull);
         expect(data?.credentials?.length, equals(10));
-      });
+      }, skip: 'TODO: unskip when fixed on the backend');
     });
   });
 }

--- a/tests/integration/typescript/credential-issuance-client-test.ts
+++ b/tests/integration/typescript/credential-issuance-client-test.ts
@@ -136,7 +136,8 @@ describe('credential-issuance-client', function () {
       expect(data.credential_responses[0]).to.have.a.property('credential')
     })
 
-    it('Retrieves issued credentials @internal', async () => {
+    // TODO: unskip when fixed on the backend
+    it.skip('Retrieves issued credentials @internal', async () => {
       const { data } = await credentialsApi.getIssuanceIdClaimedCredential(
         projectId,
         configurationId,


### PR DESCRIPTION
The issue for getIssuanceIdClaimedCredential endpoint to be addressed on the backend side.