### PR TITLE
chore: override clock dependency on example project

### DIFF
--- a/packages/dart/vault_edge_drift_provider/example/pubspec.yaml
+++ b/packages/dart/vault_edge_drift_provider/example/pubspec.yaml
@@ -19,5 +19,8 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
+dependency_overrides:
+  clock: 1.1.1
+
 flutter:
   uses-material-design: true

--- a/tests/integration/dart/test/helpers/environment.dart
+++ b/tests/integration/dart/test/helpers/environment.dart
@@ -1,10 +1,8 @@
-import 'dart:math';
 import 'dart:typed_data';
 
+import 'package:affinidi_tdk_common/affinidi_tdk_common.dart';
 import 'package:convert/convert.dart';
 import 'package:dotenv/dotenv.dart';
-
-import 'package:affinidi_tdk_common/affinidi_tdk_common.dart';
 
 class ProjectEnvironment {
   final String projectId;

--- a/tests/integration/dart/test/helpers/resource_factory.dart
+++ b/tests/integration/dart/test/helpers/resource_factory.dart
@@ -10,7 +10,6 @@ import 'package:affinidi_tdk_common/affinidi_tdk_common.dart';
 import 'package:dio/dio.dart';
 
 import 'helpers.dart';
-import 'environment.dart';
 
 class ResourceFactory {
   // NOTE: Max number of wallets for project is 10. Making clean up,

--- a/tests/integration/dart/test/helpers/resource_factory.dart
+++ b/tests/integration/dart/test/helpers/resource_factory.dart
@@ -15,7 +15,7 @@ import 'environment.dart';
 class ResourceFactory {
   // NOTE: Max number of wallets for project is 10. Making clean up,
   //       if wallet number exceeds threshold, to prevent 422 error
-  static final WALLETS_LIMIT_THRESHOLD = 7;
+  static final walletsLimitThreshold = 7;
 
   static final apiGwUrl = Environment.fetchEnvironment().apiGwUrl;
 
@@ -140,7 +140,7 @@ class ResourceFactory {
     final result = (await walletApi.listWallets()).data;
     final walletsCount = result!.wallets!.length;
 
-    if (walletsCount > WALLETS_LIMIT_THRESHOLD) {
+    if (walletsCount > walletsLimitThreshold) {
       print('❗️Number of wallets reaching the limit (10). Deleting wallets.');
 
       for (final wallet in result.wallets!) {

--- a/tests/integration/dart/test/wallets_client_test.dart
+++ b/tests/integration/dart/test/wallets_client_test.dart
@@ -5,7 +5,6 @@ import 'package:affinidi_tdk_wallets_client/affinidi_tdk_wallets_client.dart';
 import 'package:affinidi_tdk_common/affinidi_tdk_common.dart';
 
 import 'helpers/helpers.dart';
-import 'helpers/resource_factory.dart';
 
 void main() {
   group('Wallets Client Integration Tests', () {


### PR DESCRIPTION
* Override `clock` dependency with version `1.1.1` because `dart_jsonwebtoken` depends on `clock ^1.1.2` 
* Removed unused an unnecessary imports from integration tests
* Renamed variable in integration tests to use loweredCamelCase convention