### PR TITLE
feat: support DCQL vp_token in Iota response handling

### DIFF
--- a/libs/iota-browser/src/helpers/response-handler.ts
+++ b/libs/iota-browser/src/helpers/response-handler.ts
@@ -24,6 +24,10 @@ import {
 
 export class IotaResponse {
   correlationId: string
+  // For PEX this is the single presented VP. For DCQL (OID4VP 1.0 §8.1) the
+  // vp_token may carry multiple presentations (one per credential-query id);
+  // this exposes only the FIRST one for convenience — read [vpToken] for the
+  // complete DCQL structure.
   verifiablePresentation: VerifiablePresentation
   // Raw vp_token string as received. For PEX this is the single VP; for DCQL
   // (OID4VP 1.0 §8.1) it is the JSON object keyed by credential-query id.
@@ -77,11 +81,12 @@ export class ResponseHandler {
 
     const rawSubmission = responseCallback.presentationSubmission
 
-    // DCQL (OID4VP 1.0 §8.1): there is no presentation_submission, and vp_token
-    // is a JSON object keyed by credential-query id whose values are the
+    // DCQL (OID4VP 1.0 §8.1): presentation_submission is absent, and vp_token is
+    // a JSON object keyed by credential-query id whose values are the
     // presentation(s) that satisfy each query. PEX returns a single VP plus a
-    // presentation_submission.
-    if (!rawSubmission) {
+    // presentation_submission. Detect DCQL by the missing field (an empty/
+    // invalid submission string is left to fail in the PEX parsing path below).
+    if (rawSubmission === undefined) {
       let dcqlVpToken: DcqlVpToken
       try {
         dcqlVpToken = dcqlVpTokenSchema.parse(vpJson)

--- a/libs/iota-browser/src/helpers/response-handler.ts
+++ b/libs/iota-browser/src/helpers/response-handler.ts
@@ -16,21 +16,29 @@ import { Logger } from '@affinidi-tdk/common/helpers'
 import {
   PresentationSubmission,
   VerifiablePresentation,
+  DcqlVpToken,
   presentationSubmissionSchema,
   verifiablePresentationSchema,
+  dcqlVpTokenSchema,
 } from '../validators/ssi'
 
 export class IotaResponse {
   correlationId: string
   verifiablePresentation: VerifiablePresentation
-  presentationSubmission: PresentationSubmission
+  // Raw vp_token string as received. For PEX this is the single VP; for DCQL
+  // (OID4VP 1.0 §8.1) it is the JSON object keyed by credential-query id.
+  vpToken: string
+  // Absent for DCQL responses (there is no presentation_submission).
+  presentationSubmission?: PresentationSubmission
   constructor(
     correlationId: string,
     verifiablePresentation: VerifiablePresentation,
-    presentationSubmission: PresentationSubmission,
+    vpToken: string,
+    presentationSubmission?: PresentationSubmission,
   ) {
     this.correlationId = correlationId
     this.verifiablePresentation = verifiablePresentation
+    this.vpToken = vpToken
     this.presentationSubmission = presentationSubmission
   }
 }
@@ -48,8 +56,6 @@ export class ResponseHandler {
 
   private getResponseHandler(event: ResponseCallbackEvent) {
     let responseCallback: ResponseCallbackEvent
-    let verifiablePresentation: VerifiablePresentation
-    let presentationSubmission: PresentationSubmission
     try {
       responseCallback = responseCallbackEventSchema.parse(event)
     } catch (e) {
@@ -58,8 +64,52 @@ export class ResponseHandler {
         event.correlationId,
       )
     }
+
+    let vpJson: unknown
     try {
-      const vpJson = JSON.parse(responseCallback.vpToken)
+      vpJson = JSON.parse(responseCallback.vpToken)
+    } catch (e) {
+      throw newUnexpectedError(
+        InternalErrorCode.PARSING_VERIFIABLE_PRESENTATION,
+        event.correlationId,
+      )
+    }
+
+    const rawSubmission = responseCallback.presentationSubmission
+
+    // DCQL (OID4VP 1.0 §8.1): there is no presentation_submission, and vp_token
+    // is a JSON object keyed by credential-query id whose values are the
+    // presentation(s) that satisfy each query. PEX returns a single VP plus a
+    // presentation_submission.
+    if (!rawSubmission) {
+      let dcqlVpToken: DcqlVpToken
+      try {
+        dcqlVpToken = dcqlVpTokenSchema.parse(vpJson)
+      } catch (e) {
+        throw newUnexpectedError(
+          InternalErrorCode.PARSING_VERIFIABLE_PRESENTATION,
+          event.correlationId,
+        )
+      }
+      const [firstPresentation] = Object.values(dcqlVpToken).flatMap(
+        (presentation) =>
+          Array.isArray(presentation) ? presentation : [presentation],
+      )
+      if (!firstPresentation) {
+        throw newUnexpectedError(
+          InternalErrorCode.PARSING_VERIFIABLE_PRESENTATION,
+          event.correlationId,
+        )
+      }
+      return new IotaResponse(
+        responseCallback.correlationId,
+        firstPresentation,
+        responseCallback.vpToken,
+      )
+    }
+
+    let verifiablePresentation: VerifiablePresentation
+    try {
       verifiablePresentation = verifiablePresentationSchema.parse(vpJson)
     } catch (e) {
       throw newUnexpectedError(
@@ -67,12 +117,11 @@ export class ResponseHandler {
         event.correlationId,
       )
     }
+
+    let presentationSubmission: PresentationSubmission
     try {
-      const presentationSubmissionJson = JSON.parse(
-        responseCallback.presentationSubmission,
-      )
       presentationSubmission = presentationSubmissionSchema.parse(
-        presentationSubmissionJson,
+        JSON.parse(rawSubmission),
       )
     } catch (e) {
       throw newUnexpectedError(
@@ -80,13 +129,13 @@ export class ResponseHandler {
         event.correlationId,
       )
     }
-    const response = new IotaResponse(
+
+    return new IotaResponse(
       responseCallback.correlationId,
       verifiablePresentation,
+      responseCallback.vpToken,
       presentationSubmission,
     )
-
-    return response
   }
 
   async getResponse(correlationId: string): Promise<IotaResponse> {

--- a/libs/iota-browser/src/validators/error.ts
+++ b/libs/iota-browser/src/validators/error.ts
@@ -79,9 +79,8 @@ export function newRequestError(event: ErrorEvent): IotaError {
 }
 
 export function throwEventError(event: ErrorEvent): never {
-  let errorEvent: ErrorEvent
   try {
-    errorEvent = errorEventSchema.parse(event)
+    errorEventSchema.parse(event)
   } catch (e) {
     if (e instanceof Error) {
       Logger.debug(e.message)

--- a/libs/iota-browser/src/validators/events.ts
+++ b/libs/iota-browser/src/validators/events.ts
@@ -36,7 +36,9 @@ export type SignedRequestJWT = z.infer<typeof signedRequestJWTSchema>
 export const responseCallbackEventSchema = BaseEvent.extend({
   eventType: z.literal(EventTypes.ResponseCallback),
   vpToken: z.string(),
-  presentationSubmission: z.string(),
+  // Optional: DCQL responses (OID4VP 1.0 §8.1) do not include a
+  // presentation_submission; PEX responses do.
+  presentationSubmission: z.string().optional(),
 })
 export type ResponseCallbackEvent = z.infer<typeof responseCallbackEventSchema>
 

--- a/libs/iota-browser/src/validators/ssi.ts
+++ b/libs/iota-browser/src/validators/ssi.ts
@@ -78,3 +78,14 @@ export const verifiablePresentationSchema = z
 export type VerifiablePresentation = z.infer<
   typeof verifiablePresentationSchema
 >
+
+// DCQL (OID4VP 1.0 §8.1): the vp_token is a JSON object keyed by the
+// credential-query `id`, whose values are the presentation(s) that satisfy each
+// query (a single presentation, or an array when `multiple` is true).
+export const dcqlVpTokenSchema = z.record(
+  z.union([
+    verifiablePresentationSchema,
+    z.array(verifiablePresentationSchema),
+  ]),
+)
+export type DcqlVpToken = z.infer<typeof dcqlVpTokenSchema>


### PR DESCRIPTION
**Why**

OID4VP 1.0 (§8.1) DCQL responses use a different `vp_token` shape than PEX: a JSON object keyed by credential‑query id, and no `presentation_submission`. The response handler required `presentationSubmission` and expected a single Verifiable Presentation, so any DCQL response failed schema validation and surfaced as an `UnexpectedError` (ResponseCallbackEvent). This adds first‑class DCQL support to the websocket flow.

**What**

Made `presentationSubmission` optional in `responseCallbackEventSchema` (DCQL responses don't include it).
Added a DCQL `vp_token` schema (`dcqlVpToken`): an object keyed by credential‑query id mapping to the presentation(s) that satisfy each query.
Updated the response handler to parse both shapes: PEX (single VP + `presentation_submission`) and DCQL (keyed object, no submission).
`IotaResponse` now exposes the raw `vpToken` string and an optional `presentationSubmission`.

Backward compatible: PEX responses are unchanged.