### PR TITLE
fix: publish script for iota-browser

### DIFF
--- a/libs/iota-browser/package.json
+++ b/libs/iota-browser/package.json
@@ -34,7 +34,7 @@
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
     "package": "npm pack",
-    "publib-npm": "publib-npm"
+    "publish-npm": "publib-npm"
   },
   "dependencies": {
     "@affinidi-tdk/common": "^1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -338,7 +338,7 @@
     },
     "libs/iota-browser": {
       "name": "@affinidi-tdk/iota-browser",
-      "version": "1.24.1",
+      "version": "1.25.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@affinidi-tdk/common": "^1.1.1",


### PR DESCRIPTION
Root cause:

iota-browser's package.json script was named publib-npm, but its project.json release publishCmd calls `npm run publish-npm` → Missing script: "publish-npm". semantic-release runs version‑bump → git‑commit → tag+push before the publish plugin, so everything succeeded except the final npm publish. 
This has been failing for a while — npm latest is 1.20.0 while git tags reach 1.24.2, so several versions were tagged but never published.