### PR TITLE
fix: publish via @semantic-release/npm plugin

### DIFF
--- a/libs/iota-browser/package.json
+++ b/libs/iota-browser/package.json
@@ -33,8 +33,7 @@
     "build": "tsc",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
-    "package": "npm pack",
-    "publish-npm": "npm publish"
+    "package": "npm pack"
   },
   "dependencies": {
     "@affinidi-tdk/common": "^1.1.1",

--- a/libs/iota-browser/project.json
+++ b/libs/iota-browser/project.json
@@ -30,17 +30,14 @@
         "changelog": true,
         "github": true,
         "git": true,
-        "npm": false,
+        "npm": true,
         "repositoryUrl": "git@github.com:affinidi/affinidi-tdk.git",
         "branches": ["main"],
         "plugins": [
           [
-            "@semantic-release/exec",
+            "@semantic-release/npm",
             {
-              "execCwd": "{projectRoot}",
-              "prepareCmd": "npm version ${nextRelease.version}",
-              "publishCmd": "npm run publish-npm",
-              "verifyConditionsCmd": "npm version"
+              "npmPublish": true
             }
           ]
         ]


### PR DESCRIPTION
publish iota-browser (which is not jsii) via @semantic-release/npm plugin