### PR TITLE
fix(iota-browser): publish as plain npm package via @semantic-release/npm

### DIFF
--- a/libs/iota-browser/package.json
+++ b/libs/iota-browser/package.json
@@ -33,8 +33,7 @@
     "build": "tsc",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
-    "package": "npm pack",
-    "publib-npm": "publib-npm"
+    "package": "npm pack"
   },
   "dependencies": {
     "@affinidi-tdk/common": "^1.1.1",

--- a/libs/iota-browser/project.json
+++ b/libs/iota-browser/project.json
@@ -30,17 +30,14 @@
         "changelog": true,
         "github": true,
         "git": true,
-        "npm": false,
+        "npm": true,
         "repositoryUrl": "git@github.com:affinidi/affinidi-tdk.git",
         "branches": ["main"],
         "plugins": [
           [
-            "@semantic-release/exec",
+            "@semantic-release/npm",
             {
-              "execCwd": "{projectRoot}",
-              "prepareCmd": "npm version ${nextRelease.version}",
-              "publishCmd": "npm run publish-npm",
-              "verifyConditionsCmd": "npm version"
+              "npmPublish": true
             }
           ]
         ]


### PR DESCRIPTION
## Publish iota-browser as a plain npm package

### Problem
`@affinidi-tdk/iota-browser` stopped publishing to npm — npm `latest` is stuck at **1.20.0** while git tags advanced to **1.25.x**. The release job fails with:

```
[semantic-release] Call script npm run publish-npm
npm ERR! Missing script: "publish-npm"
Did you mean … npm run publib-npm
```

### Root cause
`iota-browser` is a **plain TypeScript package** (`build: tsc`), not jsii. In #535 it was moved onto the jsii/`publib` publish flow used by `iota-core`:

- `project.json` → `@semantic-release/exec` runs `npm run publish-npm`
- but `package.json` only defined `publib-npm` (and `publib` publishes jsii `dist/js` artifacts, which this package doesn't produce)

So `npm run publish-npm` had nothing to run → `Missing script` → the publish step failed → nothing reached npm.

### Fix
Restore the plain npm publish flow this package used at **v1.20.0**:

- `project.json`: switch the `semantic-release` plugin from `@semantic-release/exec` back to `@semantic-release/npm` with `npmPublish: true`, and set `npm: true`.
- `package.json`: remove the now-unused `publib-npm` script.

`iota-core` (genuinely jsii) is intentionally left unchanged.
