### PR TITLE
feat: Migrate npm publishing to trusted publishing (OIDC) + Node 24

### DIFF
--- a/.github/workflows/integration-tests-typescript.yaml
+++ b/.github/workflows/integration-tests-typescript.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/nx-branch.yaml
+++ b/.github/workflows/nx-branch.yaml
@@ -20,9 +20,11 @@ jobs:
           ref: ${{ github.head_ref }}
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: 'npm'
       - run: npm ci
+      - name: Verify npm packages are trusted-publishing ready
+        run: node -r @swc-node/register scripts/trusted-publishing/tp.ts check
       - uses: nrwl/nx-set-shas@v4
       - run: |
           echo "BASE: ${{ env.NX_BASE }}"

--- a/.github/workflows/nx-release.yaml
+++ b/.github/workflows/nx-release.yaml
@@ -36,7 +36,8 @@ jobs:
       # Setup cache, npm
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          # npm trusted publishing (OIDC) requires npm CLI >= 11.5.1, which ships with Node 24.
+          node-version: 24
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
           scope: '@affinidi-tdk'
@@ -84,12 +85,13 @@ jobs:
         name: semantic release
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # npm auth is via OIDC trusted publishing (id-token: write above); no NPM_TOKEN needed.
+          # publib (jsii packages) needs this flag to use trusted publishing instead of a token.
+          NPM_TRUSTED_PUBLISHER: 'true'
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
           MAVEN_CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
           MAVEN_GPG_SECRET_KEY_PASSWORD: ${{ secrets.MAVEN_GPG_SECRET_KEY_PASSWORD }}
           TWINE_USERNAME: '__token__'
           TWINE_PASSWORD: ${{ steps.mint.outputs.api-token }}
           POETRY_PYPI_TOKEN_PYPI: ${{ steps.mint.outputs.api-token }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           BASE_SHA: ${{ github.event.before }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -338,7 +338,7 @@
     },
     "libs/iota-browser": {
       "name": "@affinidi-tdk/iota-browser",
-      "version": "1.25.1",
+      "version": "1.25.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@affinidi-tdk/common": "^1.1.1",
@@ -685,6 +685,45 @@
     },
     "libs/iota-core/node_modules/undici-types": {
       "version": "6.11.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@actions/core": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-3.0.1.tgz",
+      "integrity": "sha512-a6d/Nwahm9fliVGRhdhofo40HjHQasUPusmc7vBfyky+7Z+P2A1J68zyFVaNcEclc/Se+eO595oAr5nwEIoIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@actions/exec": "^3.0.0",
+        "@actions/http-client": "^4.0.0"
+      }
+    },
+    "node_modules/@actions/exec": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-3.0.0.tgz",
+      "integrity": "sha512-6xH/puSoNBXb72VPlZVm7vQ+svQpFyA96qdDBvhB8eNZOE8LtPf9L4oAsfzK/crCL8YZ+19fKYVnM63Sl+Xzlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@actions/io": "^3.0.2"
+      }
+    },
+    "node_modules/@actions/http-client": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-4.0.1.tgz",
+      "integrity": "sha512-+Nvd1ImaOZBSoPbsUtEhv+1z99H12xzncCkz0a3RuehINE81FZSe2QTj3uvAPTcJX/SCzUQHQ0D1GrPMbrPitg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tunnel": "^0.0.6",
+        "undici": "^6.23.0"
+      }
+    },
+    "node_modules/@actions/io": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-3.0.2.tgz",
+      "integrity": "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==",
       "dev": true,
       "license": "MIT"
     },
@@ -7420,6 +7459,13 @@
         "node": ">=12"
       }
     },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@semantic-release/changelog": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@semantic-release/changelog/-/changelog-6.0.3.tgz",
@@ -7823,31 +7869,543 @@
       }
     },
     "node_modules/@semantic-release/npm": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-9.0.2.tgz",
-      "integrity": "sha512-zgsynF6McdzxPnFet+a4iO9HpAlARXOM5adz7VGVCvj0ne8wtL2ZOQoDV2wZPDmdEotDIbVeJjafhelZjs9j6g==",
+      "version": "13.1.5",
+      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-13.1.5.tgz",
+      "integrity": "sha512-Hq5UxzoatN3LHiq2rTsWS54nCdqJHlsssGERCo8WlvdfFA9LoN0vO+OuKVSjtNapIc/S8C2LBj206wKLHg62mg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@semantic-release/error": "^3.0.0",
-        "aggregate-error": "^3.0.0",
-        "execa": "^5.0.0",
+        "@actions/core": "^3.0.0",
+        "@semantic-release/error": "^4.0.0",
+        "aggregate-error": "^5.0.0",
+        "env-ci": "^11.2.0",
+        "execa": "^9.0.0",
         "fs-extra": "^11.0.0",
-        "lodash": "^4.17.15",
+        "lodash-es": "^4.17.21",
         "nerf-dart": "^1.0.0",
-        "normalize-url": "^6.0.0",
-        "npm": "^8.3.0",
+        "normalize-url": "^9.0.0",
+        "npm": "^11.6.2",
         "rc": "^1.2.8",
-        "read-pkg": "^5.0.0",
+        "read-pkg": "^10.0.0",
         "registry-auth-token": "^5.0.0",
         "semver": "^7.1.2",
-        "tempy": "^1.0.0"
+        "tempy": "^3.0.0"
       },
       "engines": {
-        "node": ">=16 || ^14.17"
+        "node": "^22.14.0 || >= 24.10.0"
       },
       "peerDependencies": {
-        "semantic-release": ">=19.0.0"
+        "semantic-release": ">=20.1.0"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/@semantic-release/error": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
+      "integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/aggregate-error": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-5.0.0.tgz",
+      "integrity": "sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clean-stack": "^5.2.0",
+        "indent-string": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/clean-stack": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-5.3.0.tgz",
+      "integrity": "sha512-9ngPTOhYGQqNVSfeJkYXHmF7AGWp4/nN5D/QqNQs3Dvxd1Kk/WpjHfNujKHYUQ/5CoGyOyFNoWSPk5afzP0QVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "5.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/env-ci": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-11.2.0.tgz",
+      "integrity": "sha512-D5kWfzkmaOQDioPmiviWAVtKmpPT4/iJmMVQxWxMPJTFyTkdc5JQUfc5iXEeWxcOdsYTKSAiA/Age4NUOqKsRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^8.0.0",
+        "java-properties": "^1.0.2"
+      },
+      "engines": {
+        "node": "^18.17 || >=20.6.1"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/env-ci/node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/env-ci/node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/env-ci/node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/env-ci/node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/env-ci/node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/env-ci/node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/execa": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.2.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/hosted-git-info": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+      "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^11.1.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/indent-string": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/normalize-package-data": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-8.0.0.tgz",
+      "integrity": "sha512-RWk+PI433eESQ7ounYxIp67CYuVsS1uYSonX3kA6ps/3LWfjVQa/ptEg6Y3T6uAMq1mWpX9PQ+qx+QaHpsc7gQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^9.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-license": "^3.0.4"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/normalize-url": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-9.0.1.tgz",
+      "integrity": "sha512-ARftfC5HdUNu9jJeL8pHj8debUIHA2b91FizCoMzY4lG6dDX13jdvTK0TBe24IBDRf2HvJSzzwEPvmbkQWHRSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/parse-json": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+      "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.26.2",
+        "index-to-position": "^1.1.0",
+        "type-fest": "^4.39.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/parse-json/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/read-pkg": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-10.1.0.tgz",
+      "integrity": "sha512-I8g2lArQiP78ll51UeMZojewtYgIRCKCWqZEgOO8c/uefTI+XDXvCSXu3+YNUaTNvZzobrL5+SqHjBrByRRTdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.4",
+        "normalize-package-data": "^8.0.0",
+        "parse-json": "^8.3.0",
+        "type-fest": "^5.4.4",
+        "unicorn-magic": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/read-pkg/node_modules/unicorn-magic": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
+      "integrity": "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/type-fest": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz",
+      "integrity": "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/npm/node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@semantic-release/release-notes-generator": {
@@ -8168,6 +8726,19 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -11635,13 +12206,32 @@
       "license": "MIT"
     },
     "node_modules/crypto-random-string": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
-      "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
+      "integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "type-fest": "^1.0.1"
+      },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/crypto-random-string/node_modules/type-fest": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/d": {
@@ -11891,45 +12481,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/del": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/del/-/del-6.1.1.tgz",
-      "integrity": "sha512-ua8BhapfP0JUJKC/zV9yHHDW/rDoDxP4Zhn3AkA6/xT6gY7jYXJiaeyBZznYVujhZZET+UgcbZiQ7sN3WqcImg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "globby": "^11.0.1",
-        "graceful-fs": "^4.2.4",
-        "is-glob": "^4.0.1",
-        "is-path-cwd": "^2.2.0",
-        "is-path-inside": "^3.0.2",
-        "p-map": "^4.0.0",
-        "rimraf": "^3.0.2",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/del/node_modules/p-map": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "aggregate-error": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/delayed-stream": {
@@ -14207,6 +14758,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/index-to-position": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.2.0.tgz",
+      "integrity": "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -14374,16 +14938,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/is-path-cwd": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
-      "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/is-path-inside": {
@@ -17050,26 +17604,26 @@
       }
     },
     "node_modules/npm": {
-      "version": "8.19.4",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-8.19.4.tgz",
-      "integrity": "sha512-3HANl8i9DKnUA89P4KEgVNN28EjSeDCmvEqbzOAuxCFDzdBZzjUl99zgnGpOUumvW5lvJo2HKcjrsc+tfyv1Hw==",
+      "version": "11.18.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-11.18.0.tgz",
+      "integrity": "sha512-T67M4L5wNm0cZ7EBLErcEkY1SmzEW/WJ+SADBzsFUY1UdAPfFHXFQtZ6SEXiK0+vzXysCvAsepbMaBTwnrAD+w==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
-        "@npmcli/ci-detect",
         "@npmcli/config",
         "@npmcli/fs",
         "@npmcli/map-workspaces",
+        "@npmcli/metavuln-calculator",
         "@npmcli/package-json",
+        "@npmcli/promise-spawn",
+        "@npmcli/redact",
         "@npmcli/run-script",
+        "@sigstore/tuf",
         "abbrev",
         "archy",
         "cacache",
         "chalk",
-        "chownr",
-        "cli-columns",
-        "cli-table3",
-        "columnify",
+        "ci-info",
         "fastest-levenshtein",
         "fs-minipass",
         "glob",
@@ -17083,7 +17637,6 @@
         "libnpmdiff",
         "libnpmexec",
         "libnpmfund",
-        "libnpmhook",
         "libnpmorg",
         "libnpmpack",
         "libnpmpublish",
@@ -17094,8 +17647,6 @@
         "minimatch",
         "minipass",
         "minipass-pipeline",
-        "mkdirp",
-        "mkdirp-infer-owner",
         "ms",
         "node-gyp",
         "nopt",
@@ -17106,116 +17657,105 @@
         "npm-profile",
         "npm-registry-fetch",
         "npm-user-validate",
-        "npmlog",
-        "opener",
         "p-map",
         "pacote",
         "parse-conflict-json",
         "proc-log",
         "qrcode-terminal",
         "read",
-        "read-package-json",
-        "read-package-json-fast",
-        "readdir-scoped-modules",
-        "rimraf",
         "semver",
+        "spdx-expression-parse",
         "ssri",
+        "supports-color",
         "tar",
         "text-table",
         "tiny-relative-date",
         "treeverse",
         "validate-npm-package-name",
-        "which",
-        "write-file-atomic"
+        "which"
       ],
       "dev": true,
       "license": "Artistic-2.0",
       "workspaces": [
         "docs",
         "smoke-tests",
+        "mock-globals",
+        "mock-registry",
         "workspaces/*"
       ],
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^5.6.3",
-        "@npmcli/ci-detect": "^2.0.0",
-        "@npmcli/config": "^4.2.1",
-        "@npmcli/fs": "^2.1.0",
-        "@npmcli/map-workspaces": "^2.0.3",
-        "@npmcli/package-json": "^2.0.0",
-        "@npmcli/run-script": "^4.2.1",
-        "abbrev": "~1.1.1",
+        "@npmcli/arborist": "^9.9.0",
+        "@npmcli/config": "^10.12.0",
+        "@npmcli/fs": "^5.0.0",
+        "@npmcli/map-workspaces": "^5.0.3",
+        "@npmcli/metavuln-calculator": "^9.0.3",
+        "@npmcli/package-json": "^7.0.5",
+        "@npmcli/promise-spawn": "^9.0.1",
+        "@npmcli/redact": "^4.0.0",
+        "@npmcli/run-script": "^10.0.4",
+        "@sigstore/tuf": "^4.0.2",
+        "abbrev": "^4.0.0",
         "archy": "~1.0.0",
-        "cacache": "^16.1.3",
-        "chalk": "^4.1.2",
-        "chownr": "^2.0.0",
-        "cli-columns": "^4.0.0",
-        "cli-table3": "^0.6.2",
-        "columnify": "^1.6.0",
-        "fastest-levenshtein": "^1.0.12",
-        "fs-minipass": "^2.1.0",
-        "glob": "^8.0.1",
-        "graceful-fs": "^4.2.10",
-        "hosted-git-info": "^5.2.1",
-        "ini": "^3.0.1",
-        "init-package-json": "^3.0.2",
-        "is-cidr": "^4.0.2",
-        "json-parse-even-better-errors": "^2.3.1",
-        "libnpmaccess": "^6.0.4",
-        "libnpmdiff": "^4.0.5",
-        "libnpmexec": "^4.0.14",
-        "libnpmfund": "^3.0.5",
-        "libnpmhook": "^8.0.4",
-        "libnpmorg": "^4.0.4",
-        "libnpmpack": "^4.1.3",
-        "libnpmpublish": "^6.0.5",
-        "libnpmsearch": "^5.0.4",
-        "libnpmteam": "^4.0.4",
-        "libnpmversion": "^3.0.7",
-        "make-fetch-happen": "^10.2.0",
-        "minimatch": "^5.1.0",
-        "minipass": "^3.1.6",
+        "cacache": "^20.0.4",
+        "chalk": "^5.6.2",
+        "ci-info": "^4.4.0",
+        "fastest-levenshtein": "^1.0.16",
+        "fs-minipass": "^3.0.3",
+        "glob": "^13.0.6",
+        "graceful-fs": "^4.2.11",
+        "hosted-git-info": "^9.0.3",
+        "ini": "^6.0.0",
+        "init-package-json": "^8.2.5",
+        "is-cidr": "^6.0.4",
+        "json-parse-even-better-errors": "^5.0.0",
+        "libnpmaccess": "^10.0.3",
+        "libnpmdiff": "^8.1.11",
+        "libnpmexec": "^10.3.1",
+        "libnpmfund": "^7.0.25",
+        "libnpmorg": "^8.0.1",
+        "libnpmpack": "^9.1.11",
+        "libnpmpublish": "^11.2.0",
+        "libnpmsearch": "^9.0.1",
+        "libnpmteam": "^8.0.2",
+        "libnpmversion": "^8.0.4",
+        "make-fetch-happen": "^15.0.6",
+        "minimatch": "^10.2.5",
+        "minipass": "^7.1.3",
         "minipass-pipeline": "^1.2.4",
-        "mkdirp": "^1.0.4",
-        "mkdirp-infer-owner": "^2.0.0",
         "ms": "^2.1.2",
-        "node-gyp": "^9.1.0",
-        "nopt": "^6.0.0",
-        "npm-audit-report": "^3.0.0",
-        "npm-install-checks": "^5.0.0",
-        "npm-package-arg": "^9.1.0",
-        "npm-pick-manifest": "^7.0.2",
-        "npm-profile": "^6.2.0",
-        "npm-registry-fetch": "^13.3.1",
-        "npm-user-validate": "^1.0.1",
-        "npmlog": "^6.0.2",
-        "opener": "^1.5.2",
-        "p-map": "^4.0.0",
-        "pacote": "^13.6.2",
-        "parse-conflict-json": "^2.0.2",
-        "proc-log": "^2.0.1",
+        "node-gyp": "^12.4.0",
+        "nopt": "^9.0.0",
+        "npm-audit-report": "^7.0.0",
+        "npm-install-checks": "^8.0.0",
+        "npm-package-arg": "^13.0.2",
+        "npm-pick-manifest": "^11.0.3",
+        "npm-profile": "^12.0.2",
+        "npm-registry-fetch": "^19.1.1",
+        "npm-user-validate": "^4.0.0",
+        "p-map": "^7.0.4",
+        "pacote": "^21.5.1",
+        "parse-conflict-json": "^5.0.1",
+        "proc-log": "^6.1.0",
         "qrcode-terminal": "^0.12.0",
-        "read": "~1.0.7",
-        "read-package-json": "^5.0.2",
-        "read-package-json-fast": "^2.0.3",
-        "readdir-scoped-modules": "^1.1.0",
-        "rimraf": "^3.0.2",
-        "semver": "^7.3.7",
-        "ssri": "^9.0.1",
-        "tar": "^6.1.11",
+        "read": "^5.0.1",
+        "semver": "^7.8.5",
+        "spdx-expression-parse": "^4.0.0",
+        "ssri": "^13.0.1",
+        "supports-color": "^10.2.2",
+        "tar": "^7.5.19",
         "text-table": "~0.2.0",
-        "tiny-relative-date": "^1.3.0",
-        "treeverse": "^2.0.0",
-        "validate-npm-package-name": "^4.0.0",
-        "which": "^2.0.2",
-        "write-file-atomic": "^4.0.1"
+        "tiny-relative-date": "^2.0.2",
+        "treeverse": "^3.0.0",
+        "validate-npm-package-name": "^7.0.2",
+        "which": "^6.0.1"
       },
       "bin": {
         "npm": "bin/npm-cli.js",
         "npx": "bin/npx-cli.js"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm-package-arg": {
@@ -17247,21 +17787,26 @@
         "node": ">=8"
       }
     },
-    "node_modules/npm/node_modules/@colors/colors": {
-      "version": "1.5.0",
+    "node_modules/npm/node_modules/@gar/promise-retry": {
+      "version": "1.0.3",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
-        "node": ">=0.1.90"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/npm/node_modules/@gar/promisify": {
-      "version": "1.1.3",
+    "node_modules/npm/node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/npm/node_modules/@isaacs/string-locale-compare": {
       "version": "1.1.0",
@@ -17269,347 +17814,368 @@
       "inBundle": true,
       "license": "ISC"
     },
-    "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "5.6.3",
+    "node_modules/npm/node_modules/@npmcli/agent": {
+      "version": "4.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
+        "agent-base": "^7.1.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "lru-cache": "^11.2.1",
+        "socks-proxy-agent": "^8.0.3"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/arborist": {
+      "version": "9.9.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@gar/promise-retry": "^1.0.0",
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/installed-package-contents": "^1.0.7",
-        "@npmcli/map-workspaces": "^2.0.3",
-        "@npmcli/metavuln-calculator": "^3.0.1",
-        "@npmcli/move-file": "^2.0.0",
-        "@npmcli/name-from-folder": "^1.0.1",
-        "@npmcli/node-gyp": "^2.0.0",
-        "@npmcli/package-json": "^2.0.0",
-        "@npmcli/query": "^1.2.0",
-        "@npmcli/run-script": "^4.1.3",
-        "bin-links": "^3.0.3",
-        "cacache": "^16.1.3",
-        "common-ancestor-path": "^1.0.1",
-        "hosted-git-info": "^5.2.1",
-        "json-parse-even-better-errors": "^2.3.1",
+        "@npmcli/fs": "^5.0.0",
+        "@npmcli/installed-package-contents": "^4.0.0",
+        "@npmcli/map-workspaces": "^5.0.0",
+        "@npmcli/metavuln-calculator": "^9.0.2",
+        "@npmcli/name-from-folder": "^4.0.0",
+        "@npmcli/node-gyp": "^5.0.0",
+        "@npmcli/package-json": "^7.0.0",
+        "@npmcli/query": "^5.0.0",
+        "@npmcli/redact": "^4.0.0",
+        "@npmcli/run-script": "^10.0.0",
+        "bin-links": "^6.0.0",
+        "cacache": "^20.0.1",
+        "common-ancestor-path": "^2.0.0",
+        "hosted-git-info": "^9.0.0",
         "json-stringify-nice": "^1.1.4",
-        "minimatch": "^5.1.0",
-        "mkdirp": "^1.0.4",
-        "mkdirp-infer-owner": "^2.0.0",
-        "nopt": "^6.0.0",
-        "npm-install-checks": "^5.0.0",
-        "npm-package-arg": "^9.0.0",
-        "npm-pick-manifest": "^7.0.2",
-        "npm-registry-fetch": "^13.0.0",
-        "npmlog": "^6.0.2",
-        "pacote": "^13.6.1",
-        "parse-conflict-json": "^2.0.1",
-        "proc-log": "^2.0.0",
+        "lru-cache": "^11.2.1",
+        "minimatch": "^10.0.3",
+        "nopt": "^9.0.0",
+        "npm-install-checks": "^8.0.0",
+        "npm-package-arg": "^13.0.0",
+        "npm-pick-manifest": "^11.0.1",
+        "npm-registry-fetch": "^19.0.0",
+        "pacote": "^21.0.2",
+        "parse-conflict-json": "^5.0.1",
+        "proc-log": "^6.0.0",
+        "proggy": "^4.0.0",
         "promise-all-reject-late": "^1.0.0",
-        "promise-call-limit": "^1.0.1",
-        "read-package-json-fast": "^2.0.2",
-        "readdir-scoped-modules": "^1.1.0",
-        "rimraf": "^3.0.2",
+        "promise-call-limit": "^3.0.1",
         "semver": "^7.3.7",
-        "ssri": "^9.0.0",
-        "treeverse": "^2.0.0",
-        "walk-up-path": "^1.0.0"
+        "ssri": "^13.0.0",
+        "treeverse": "^3.0.0",
+        "walk-up-path": "^4.0.0"
       },
       "bin": {
         "arborist": "bin/index.js"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/ci-detect": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "4.2.2",
+      "version": "10.12.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/map-workspaces": "^2.0.2",
-        "ini": "^3.0.0",
-        "mkdirp-infer-owner": "^2.0.0",
-        "nopt": "^6.0.0",
-        "proc-log": "^2.0.0",
-        "read-package-json-fast": "^2.0.3",
+        "@npmcli/map-workspaces": "^5.0.0",
+        "@npmcli/package-json": "^7.0.0",
+        "ci-info": "^4.0.0",
+        "ini": "^6.0.0",
+        "nopt": "^9.0.0",
+        "proc-log": "^6.0.0",
         "semver": "^7.3.5",
-        "walk-up-path": "^1.0.0"
+        "walk-up-path": "^4.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/disparity-colors": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "ansi-styles": "^4.3.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/fs": {
-      "version": "2.1.2",
+      "version": "5.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@gar/promisify": "^1.1.3",
         "semver": "^7.3.5"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/git": {
-      "version": "3.0.2",
+      "version": "7.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/promise-spawn": "^3.0.0",
-        "lru-cache": "^7.4.4",
-        "mkdirp": "^1.0.4",
-        "npm-pick-manifest": "^7.0.0",
-        "proc-log": "^2.0.0",
-        "promise-inflight": "^1.0.1",
-        "promise-retry": "^2.0.1",
+        "@gar/promise-retry": "^1.0.0",
+        "@npmcli/promise-spawn": "^9.0.0",
+        "ini": "^6.0.0",
+        "lru-cache": "^11.2.1",
+        "npm-pick-manifest": "^11.0.1",
+        "proc-log": "^6.0.0",
         "semver": "^7.3.5",
-        "which": "^2.0.2"
+        "which": "^6.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/installed-package-contents": {
-      "version": "1.0.7",
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "npm-bundled": "^1.1.1",
-        "npm-normalize-package-bin": "^1.0.1"
+        "npm-bundled": "^5.0.0",
+        "npm-normalize-package-bin": "^5.0.0"
       },
       "bin": {
-        "installed-package-contents": "index.js"
+        "installed-package-contents": "bin/index.js"
       },
       "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/installed-package-contents/node_modules/npm-bundled": {
-      "version": "1.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-normalize-package-bin": "^1.0.1"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/map-workspaces": {
-      "version": "2.0.4",
+      "version": "5.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/name-from-folder": "^1.0.1",
-        "glob": "^8.0.1",
-        "minimatch": "^5.0.1",
-        "read-package-json-fast": "^2.0.3"
+        "@npmcli/name-from-folder": "^4.0.0",
+        "@npmcli/package-json": "^7.0.0",
+        "glob": "^13.0.0",
+        "minimatch": "^10.0.3"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
-      "version": "3.1.1",
+      "version": "9.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "cacache": "^16.0.0",
-        "json-parse-even-better-errors": "^2.3.1",
-        "pacote": "^13.0.3",
+        "cacache": "^20.0.0",
+        "json-parse-even-better-errors": "^5.0.0",
+        "pacote": "^21.0.0",
+        "proc-log": "^6.0.0",
         "semver": "^7.3.5"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/move-file": {
-      "version": "2.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "mkdirp": "^1.0.4",
-        "rimraf": "^3.0.2"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/name-from-folder": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/@npmcli/node-gyp": {
-      "version": "2.0.0",
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/node-gyp": {
+      "version": "5.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/package-json": {
-      "version": "2.0.0",
+      "version": "7.0.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "json-parse-even-better-errors": "^2.3.1"
+        "@npmcli/git": "^7.0.0",
+        "glob": "^13.0.0",
+        "hosted-git-info": "^9.0.0",
+        "json-parse-even-better-errors": "^5.0.0",
+        "proc-log": "^6.0.0",
+        "semver": "^7.5.3",
+        "spdx-expression-parse": "^4.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/promise-spawn": {
-      "version": "3.0.0",
+      "version": "9.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "infer-owner": "^1.0.4"
+        "which": "^6.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/query": {
-      "version": "1.2.0",
+      "version": "5.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "npm-package-arg": "^9.1.0",
-        "postcss-selector-parser": "^6.0.10",
-        "semver": "^7.3.7"
+        "postcss-selector-parser": "^7.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/redact": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/run-script": {
-      "version": "4.2.1",
+      "version": "10.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/node-gyp": "^2.0.0",
-        "@npmcli/promise-spawn": "^3.0.0",
-        "node-gyp": "^9.0.0",
-        "read-package-json-fast": "^2.0.3",
-        "which": "^2.0.2"
+        "@npmcli/node-gyp": "^5.0.0",
+        "@npmcli/package-json": "^7.0.0",
+        "@npmcli/promise-spawn": "^9.0.0",
+        "node-gyp": "^12.1.0",
+        "proc-log": "^6.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/npm/node_modules/@tootallnate/once": {
+    "node_modules/npm/node_modules/@sigstore/bundle": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sigstore/protobuf-specs": "^0.5.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/@sigstore/core": {
+      "version": "3.2.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
+      "version": "0.5.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/@sigstore/sign": {
+      "version": "4.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@gar/promise-retry": "^1.0.2",
+        "@sigstore/bundle": "^4.0.0",
+        "@sigstore/core": "^3.2.0",
+        "@sigstore/protobuf-specs": "^0.5.0",
+        "make-fetch-happen": "^15.0.4",
+        "proc-log": "^6.1.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/@sigstore/tuf": {
+      "version": "4.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sigstore/protobuf-specs": "^0.5.0",
+        "tuf-js": "^4.1.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/@sigstore/verify": {
+      "version": "3.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sigstore/bundle": "^4.0.0",
+        "@sigstore/core": "^3.2.1",
+        "@sigstore/protobuf-specs": "^0.5.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/@tufjs/canonical-json": {
       "version": "2.0.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 10"
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/@tufjs/models": {
+      "version": "4.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tufjs/canonical-json": "2.0.0",
+        "minimatch": "^10.1.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/abbrev": {
-      "version": "1.1.1",
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
     },
     "node_modules/npm/node_modules/agent-base": {
-      "version": "6.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/agentkeepalive": {
-      "version": "4.2.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.1.0",
-        "depd": "^1.1.2",
-        "humanize-ms": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/aggregate-error": {
-      "version": "3.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "clean-stack": "^2.0.0",
-        "indent-string": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/ansi-regex": {
-      "version": "5.0.1",
+      "version": "7.1.4",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+        "node": ">= 14"
       }
     },
     "node_modules/npm/node_modules/aproba": {
-      "version": "2.0.0",
+      "version": "2.1.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
@@ -17620,265 +18186,138 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/npm/node_modules/are-we-there-yet": {
-      "version": "3.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/asap": {
-      "version": "2.0.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
     "node_modules/npm/node_modules/balanced-match": {
-      "version": "1.0.2",
+      "version": "4.0.4",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/npm/node_modules/bin-links": {
-      "version": "3.0.3",
+      "version": "6.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "cmd-shim": "^5.0.0",
-        "mkdirp-infer-owner": "^2.0.0",
-        "npm-normalize-package-bin": "^2.0.0",
-        "read-cmd-shim": "^3.0.0",
-        "rimraf": "^3.0.0",
-        "write-file-atomic": "^4.0.0"
+        "cmd-shim": "^8.0.0",
+        "npm-normalize-package-bin": "^5.0.0",
+        "proc-log": "^6.0.0",
+        "read-cmd-shim": "^6.0.0",
+        "write-file-atomic": "^7.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/bin-links/node_modules/npm-normalize-package-bin": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/binary-extensions": {
-      "version": "2.2.0",
+      "version": "3.1.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=18.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/npm/node_modules/brace-expansion": {
-      "version": "2.0.1",
+      "version": "5.0.7",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/builtins": {
-      "version": "5.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/npm/node_modules/cacache": {
-      "version": "16.1.3",
+      "version": "20.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/fs": "^2.1.0",
-        "@npmcli/move-file": "^2.0.0",
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.1.0",
-        "glob": "^8.0.1",
-        "infer-owner": "^1.0.4",
-        "lru-cache": "^7.7.1",
-        "minipass": "^3.1.6",
-        "minipass-collect": "^1.0.2",
+        "@npmcli/fs": "^5.0.0",
+        "fs-minipass": "^3.0.0",
+        "glob": "^13.0.0",
+        "lru-cache": "^11.1.0",
+        "minipass": "^7.0.3",
+        "minipass-collect": "^2.0.1",
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
-        "mkdirp": "^1.0.4",
-        "p-map": "^4.0.0",
-        "promise-inflight": "^1.0.1",
-        "rimraf": "^3.0.2",
-        "ssri": "^9.0.0",
-        "tar": "^6.1.11",
-        "unique-filename": "^2.0.0"
+        "p-map": "^7.0.2",
+        "ssri": "^13.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/chalk": {
-      "version": "4.1.2",
+      "version": "5.6.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
       "engines": {
-        "node": ">=10"
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/npm/node_modules/chownr": {
-      "version": "2.0.0",
+      "version": "3.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
+      }
+    },
+    "node_modules/npm/node_modules/ci-info": {
+      "version": "4.4.0",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/npm/node_modules/cidr-regex": {
-      "version": "3.1.1",
+      "version": "5.0.5",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
-      "dependencies": {
-        "ip-regex": "^4.1.0"
-      },
       "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/clean-stack": {
-      "version": "2.2.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/npm/node_modules/cli-columns": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/npm/node_modules/cli-table3": {
-      "version": "0.6.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "string-width": "^4.2.0"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      },
-      "optionalDependencies": {
-        "@colors/colors": "1.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/clone": {
-      "version": "1.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
+        "node": ">=20"
       }
     },
     "node_modules/npm/node_modules/cmd-shim": {
-      "version": "5.0.0",
+      "version": "8.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "dependencies": {
-        "mkdirp-infer-owner": "^2.0.0"
-      },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/color-convert": {
-      "version": "2.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/color-name": {
-      "version": "1.1.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/color-support": {
-      "version": "1.1.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "color-support": "bin.js"
-      }
-    },
-    "node_modules/npm/node_modules/columnify": {
-      "version": "1.6.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "strip-ansi": "^6.0.1",
-        "wcwidth": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/common-ancestor-path": {
-      "version": "1.0.1",
+      "version": "2.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/concat-map": {
-      "version": "0.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/console-control-strings": {
-      "version": "1.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/npm/node_modules/cssesc": {
       "version": "3.0.0",
@@ -17893,12 +18332,12 @@
       }
     },
     "node_modules/npm/node_modules/debug": {
-      "version": "4.3.4",
+      "version": "4.4.3",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -17909,78 +18348,13 @@
         }
       }
     },
-    "node_modules/npm/node_modules/debug/node_modules/ms": {
-      "version": "2.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/debuglog": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/npm/node_modules/defaults": {
-      "version": "1.0.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "clone": "^1.0.2"
-      }
-    },
-    "node_modules/npm/node_modules/delegates": {
-      "version": "1.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/depd": {
-      "version": "1.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/npm/node_modules/dezalgo": {
-      "version": "1.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "asap": "^2.0.0",
-        "wrappy": "1"
-      }
-    },
     "node_modules/npm/node_modules/diff": {
-      "version": "5.1.0",
+      "version": "8.0.4",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
-      }
-    },
-    "node_modules/npm/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/encoding": {
-      "version": "0.1.13",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
       }
     },
     "node_modules/npm/node_modules/env-paths": {
@@ -17992,169 +18366,102 @@
         "node": ">=6"
       }
     },
-    "node_modules/npm/node_modules/err-code": {
-      "version": "2.0.3",
+    "node_modules/npm/node_modules/exponential-backoff": {
+      "version": "3.1.3",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "Apache-2.0"
     },
     "node_modules/npm/node_modules/fastest-levenshtein": {
-      "version": "1.0.12",
+      "version": "1.0.16",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/fs-minipass": {
-      "version": "2.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
+      "license": "MIT",
       "engines": {
-        "node": ">= 8"
+        "node": ">= 4.9.1"
       }
     },
-    "node_modules/npm/node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/function-bind": {
-      "version": "1.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/gauge": {
-      "version": "4.0.4",
+    "node_modules/npm/node_modules/fs-minipass": {
+      "version": "3.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "aproba": "^1.0.3 || ^2.0.0",
-        "color-support": "^1.1.3",
-        "console-control-strings": "^1.1.0",
-        "has-unicode": "^2.0.1",
-        "signal-exit": "^3.0.7",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1",
-        "wide-align": "^1.1.5"
+        "minipass": "^7.0.3"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/glob": {
-      "version": "8.0.3",
+      "version": "13.0.6",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^5.0.1",
-        "once": "^1.3.0"
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
       },
       "engines": {
-        "node": ">=12"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/npm/node_modules/graceful-fs": {
-      "version": "4.2.10",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/has": {
-      "version": "1.0.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/npm/node_modules/has-flag": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/has-unicode": {
-      "version": "2.0.1",
+      "version": "4.2.11",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/hosted-git-info": {
-      "version": "5.2.1",
+      "version": "9.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "lru-cache": "^7.5.1"
+        "lru-cache": "^11.1.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/http-cache-semantics": {
-      "version": "4.1.1",
+      "version": "4.2.0",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/npm/node_modules/http-proxy-agent": {
-      "version": "5.0.0",
+      "version": "7.0.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "@tootallnate/once": "2",
-        "agent-base": "6",
-        "debug": "4"
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
       }
     },
     "node_modules/npm/node_modules/https-proxy-agent": {
-      "version": "5.0.1",
+      "version": "7.0.6",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "agent-base": "6",
+        "agent-base": "^7.1.2",
         "debug": "4"
       },
       "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/npm/node_modules/humanize-ms": {
-      "version": "1.2.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.0.0"
+        "node": ">= 14"
       }
     },
     "node_modules/npm/node_modules/iconv-lite": {
-      "version": "0.6.3",
+      "version": "0.7.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -18164,152 +18471,88 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/npm/node_modules/ignore-walk": {
-      "version": "5.0.1",
+      "version": "8.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "minimatch": "^5.0.1"
+        "minimatch": "^10.0.3"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
-    },
-    "node_modules/npm/node_modules/imurmurhash": {
-      "version": "0.1.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.19"
-      }
-    },
-    "node_modules/npm/node_modules/indent-string": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/infer-owner": {
-      "version": "1.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/inflight": {
-      "version": "1.0.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "node_modules/npm/node_modules/inherits": {
-      "version": "2.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
     },
     "node_modules/npm/node_modules/ini": {
-      "version": "3.0.1",
+      "version": "6.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/init-package-json": {
-      "version": "3.0.2",
+      "version": "8.2.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "npm-package-arg": "^9.0.1",
-        "promzard": "^0.3.0",
-        "read": "^1.0.7",
-        "read-package-json": "^5.0.0",
-        "semver": "^7.3.5",
-        "validate-npm-package-license": "^3.0.4",
-        "validate-npm-package-name": "^4.0.0"
+        "@npmcli/package-json": "^7.0.0",
+        "npm-package-arg": "^13.0.0",
+        "promzard": "^3.0.1",
+        "read": "^5.0.1",
+        "semver": "^7.7.2",
+        "validate-npm-package-name": "^7.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/npm/node_modules/ip": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/ip-regex": {
-      "version": "4.3.0",
+    "node_modules/npm/node_modules/ip-address": {
+      "version": "10.2.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">= 12"
       }
     },
     "node_modules/npm/node_modules/is-cidr": {
-      "version": "4.0.2",
+      "version": "6.0.4",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "cidr-regex": "^3.1.1"
+        "cidr-regex": "^5.0.4"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=20"
       }
-    },
-    "node_modules/npm/node_modules/is-core-module": {
-      "version": "2.10.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "has": "^1.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/npm/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/is-lambda": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
     },
     "node_modules/npm/node_modules/isexe": {
-      "version": "2.0.0",
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/npm/node_modules/json-parse-even-better-errors": {
-      "version": "2.3.1",
+      "version": "5.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
     },
     "node_modules/npm/node_modules/json-stringify-nice": {
       "version": "1.1.4",
@@ -18330,294 +18573,267 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/just-diff": {
-      "version": "5.1.1",
+      "version": "6.0.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/just-diff-apply": {
-      "version": "5.4.1",
+      "version": "5.5.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/libnpmaccess": {
-      "version": "6.0.4",
+      "version": "10.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-package-arg": "^13.0.0",
+        "npm-registry-fetch": "^19.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmdiff": {
+      "version": "8.1.11",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/arborist": "^9.9.0",
+        "@npmcli/installed-package-contents": "^4.0.0",
+        "binary-extensions": "^3.0.0",
+        "diff": "^8.0.2",
+        "minimatch": "^10.0.3",
+        "npm-package-arg": "^13.0.0",
+        "pacote": "^21.0.2",
+        "tar": "^7.5.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmexec": {
+      "version": "10.3.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@gar/promise-retry": "^1.0.0",
+        "@npmcli/arborist": "^9.9.0",
+        "@npmcli/package-json": "^7.0.0",
+        "@npmcli/run-script": "^10.0.0",
+        "ci-info": "^4.0.0",
+        "npm-package-arg": "^13.0.0",
+        "pacote": "^21.0.2",
+        "proc-log": "^6.0.0",
+        "read": "^5.0.1",
+        "semver": "^7.3.7",
+        "signal-exit": "^4.1.0",
+        "walk-up-path": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmfund": {
+      "version": "7.0.25",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/arborist": "^9.9.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmorg": {
+      "version": "8.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "aproba": "^2.0.0",
-        "minipass": "^3.1.1",
-        "npm-package-arg": "^9.0.1",
-        "npm-registry-fetch": "^13.0.0"
+        "npm-registry-fetch": "^19.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "4.0.5",
+    "node_modules/npm/node_modules/libnpmpack": {
+      "version": "9.1.11",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/disparity-colors": "^2.0.0",
-        "@npmcli/installed-package-contents": "^1.0.7",
-        "binary-extensions": "^2.2.0",
-        "diff": "^5.1.0",
-        "minimatch": "^5.0.1",
-        "npm-package-arg": "^9.0.1",
-        "pacote": "^13.6.1",
-        "tar": "^6.1.0"
+        "@npmcli/arborist": "^9.9.0",
+        "@npmcli/run-script": "^10.0.0",
+        "npm-package-arg": "^13.0.0",
+        "pacote": "^21.0.2"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/npm/node_modules/libnpmexec": {
-      "version": "4.0.14",
+    "node_modules/npm/node_modules/libnpmpublish": {
+      "version": "11.2.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^5.6.3",
-        "@npmcli/ci-detect": "^2.0.0",
-        "@npmcli/fs": "^2.1.1",
-        "@npmcli/run-script": "^4.2.0",
-        "chalk": "^4.1.0",
-        "mkdirp-infer-owner": "^2.0.0",
-        "npm-package-arg": "^9.0.1",
-        "npmlog": "^6.0.2",
-        "pacote": "^13.6.1",
-        "proc-log": "^2.0.0",
-        "read": "^1.0.7",
-        "read-package-json-fast": "^2.0.2",
+        "@npmcli/package-json": "^7.0.0",
+        "ci-info": "^4.0.0",
+        "npm-package-arg": "^13.0.0",
+        "npm-registry-fetch": "^19.0.0",
+        "proc-log": "^6.0.0",
         "semver": "^7.3.7",
-        "walk-up-path": "^1.0.0"
+        "sigstore": "^4.0.0",
+        "ssri": "^13.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/npm/node_modules/libnpmfund": {
-      "version": "3.0.5",
+    "node_modules/npm/node_modules/libnpmsearch": {
+      "version": "9.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^5.6.3"
+        "npm-registry-fetch": "^19.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/npm/node_modules/libnpmhook": {
+    "node_modules/npm/node_modules/libnpmteam": {
+      "version": "8.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^2.0.0",
+        "npm-registry-fetch": "^19.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmversion": {
       "version": "8.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "aproba": "^2.0.0",
-        "npm-registry-fetch": "^13.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmorg": {
-      "version": "4.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^2.0.0",
-        "npm-registry-fetch": "^13.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmpack": {
-      "version": "4.1.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/run-script": "^4.1.3",
-        "npm-package-arg": "^9.0.1",
-        "pacote": "^13.6.1"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmpublish": {
-      "version": "6.0.5",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "normalize-package-data": "^4.0.0",
-        "npm-package-arg": "^9.0.1",
-        "npm-registry-fetch": "^13.0.0",
-        "semver": "^7.3.7",
-        "ssri": "^9.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmsearch": {
-      "version": "5.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-registry-fetch": "^13.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmteam": {
-      "version": "4.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^2.0.0",
-        "npm-registry-fetch": "^13.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmversion": {
-      "version": "3.0.7",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/git": "^3.0.0",
-        "@npmcli/run-script": "^4.1.3",
-        "json-parse-even-better-errors": "^2.3.1",
-        "proc-log": "^2.0.0",
+        "@npmcli/git": "^7.0.0",
+        "@npmcli/run-script": "^10.0.0",
+        "json-parse-even-better-errors": "^5.0.0",
+        "proc-log": "^6.0.0",
         "semver": "^7.3.7"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/lru-cache": {
-      "version": "7.13.2",
+      "version": "11.5.1",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
-        "node": ">=12"
+        "node": "20 || >=22"
       }
     },
     "node_modules/npm/node_modules/make-fetch-happen": {
-      "version": "10.2.1",
+      "version": "15.0.6",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "agentkeepalive": "^4.2.1",
-        "cacache": "^16.1.0",
-        "http-cache-semantics": "^4.1.0",
-        "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "is-lambda": "^1.0.1",
-        "lru-cache": "^7.7.1",
-        "minipass": "^3.1.6",
-        "minipass-collect": "^1.0.2",
-        "minipass-fetch": "^2.0.3",
+        "@gar/promise-retry": "^1.0.0",
+        "@npmcli/agent": "^4.0.0",
+        "@npmcli/redact": "^4.0.0",
+        "cacache": "^20.0.1",
+        "http-cache-semantics": "^4.1.1",
+        "minipass": "^7.0.2",
+        "minipass-fetch": "^5.0.0",
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
-        "negotiator": "^0.6.3",
-        "promise-retry": "^2.0.1",
-        "socks-proxy-agent": "^7.0.0",
-        "ssri": "^9.0.0"
+        "negotiator": "^1.0.0",
+        "proc-log": "^6.0.0",
+        "ssri": "^13.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/minimatch": {
-      "version": "5.1.0",
+      "version": "10.2.5",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": ">=10"
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/npm/node_modules/minipass": {
-      "version": "3.3.4",
+      "version": "7.1.3",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
+      "license": "BlueOak-1.0.0",
       "engines": {
-        "node": ">=8"
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/npm/node_modules/minipass-collect": {
-      "version": "1.0.2",
+      "version": "2.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "minipass": "^3.0.0"
+        "minipass": "^7.0.3"
       },
       "engines": {
-        "node": ">= 8"
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/npm/node_modules/minipass-fetch": {
-      "version": "2.1.1",
+      "version": "5.0.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "minipass": "^3.1.6",
-        "minipass-sized": "^1.0.3",
-        "minizlib": "^2.1.2"
+        "minipass": "^7.0.3",
+        "minipass-sized": "^2.0.0",
+        "minizlib": "^3.0.1"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^20.17.0 || >=22.9.0"
       },
       "optionalDependencies": {
-        "encoding": "^0.1.13"
+        "iconv-lite": "^0.7.2"
       }
     },
     "node_modules/npm/node_modules/minipass-flush": {
-      "version": "1.0.5",
+      "version": "1.0.6",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "minipass": "^3.0.0"
+        "minipass": "^7.1.3"
       },
       "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-json-stream": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "jsonparse": "^1.3.1",
-        "minipass": "^3.0.0"
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/npm/node_modules/minipass-pipeline": {
@@ -18632,55 +18848,46 @@
         "node": ">=8"
       }
     },
-    "node_modules/npm/node_modules/minipass-sized": {
-      "version": "1.0.3",
+    "node_modules/npm/node_modules/minipass-pipeline/node_modules/minipass": {
+      "version": "3.3.6",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "minipass": "^3.0.0"
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/minipass-pipeline/node_modules/yallist": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/minipass-sized": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.1.2"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/npm/node_modules/minizlib": {
-      "version": "2.1.2",
+      "version": "3.1.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
+        "minipass": "^7.1.2"
       },
       "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/npm/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/mkdirp-infer-owner": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "chownr": "^2.0.0",
-        "infer-owner": "^1.0.4",
-        "mkdirp": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=10"
+        "node": ">= 18"
       }
     },
     "node_modules/npm/node_modules/ms": {
@@ -18690,13 +18897,16 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/mute-stream": {
-      "version": "0.0.8",
+      "version": "3.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
     },
     "node_modules/npm/node_modules/negotiator": {
-      "version": "0.6.3",
+      "version": "1.0.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -18705,151 +18915,67 @@
       }
     },
     "node_modules/npm/node_modules/node-gyp": {
-      "version": "9.1.0",
+      "version": "12.4.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "env-paths": "^2.2.0",
-        "glob": "^7.1.4",
+        "exponential-backoff": "^3.1.1",
         "graceful-fs": "^4.2.6",
-        "make-fetch-happen": "^10.0.3",
-        "nopt": "^5.0.0",
-        "npmlog": "^6.0.0",
-        "rimraf": "^3.0.2",
+        "nopt": "^9.0.0",
+        "proc-log": "^6.0.0",
         "semver": "^7.3.5",
-        "tar": "^6.1.2",
-        "which": "^2.0.2"
+        "tar": "^7.5.4",
+        "tinyglobby": "^0.2.12",
+        "undici": "^6.25.0",
+        "which": "^6.0.0"
       },
       "bin": {
         "node-gyp": "bin/node-gyp.js"
       },
       "engines": {
-        "node": "^12.22 || ^14.13 || >=16"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/glob": {
-      "version": "7.2.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/minimatch": {
-      "version": "3.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/nopt": {
-      "version": "5.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "abbrev": "1"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
-      },
-      "engines": {
-        "node": ">=6"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/nopt": {
-      "version": "6.0.0",
+      "version": "9.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "abbrev": "^1.0.0"
+        "abbrev": "^4.0.0"
       },
       "bin": {
         "nopt": "bin/nopt.js"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/normalize-package-data": {
-      "version": "4.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "hosted-git-info": "^5.0.0",
-        "is-core-module": "^2.8.1",
-        "semver": "^7.3.5",
-        "validate-npm-package-license": "^3.0.4"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/npm-audit-report": {
-      "version": "3.0.0",
+      "version": "7.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "dependencies": {
-        "chalk": "^4.0.0"
-      },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/npm-bundled": {
-      "version": "2.0.1",
+      "version": "5.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "npm-normalize-package-bin": "^2.0.0"
+        "npm-normalize-package-bin": "^5.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/npm-bundled/node_modules/npm-normalize-package-bin": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/npm-install-checks": {
-      "version": "5.0.0",
+      "version": "8.0.0",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -18857,226 +18983,177 @@
         "semver": "^7.1.1"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/npm-normalize-package-bin": {
-      "version": "1.0.1",
+      "version": "5.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
     },
     "node_modules/npm/node_modules/npm-package-arg": {
-      "version": "9.1.0",
+      "version": "13.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "hosted-git-info": "^5.0.0",
-        "proc-log": "^2.0.1",
+        "hosted-git-info": "^9.0.0",
+        "proc-log": "^6.0.0",
         "semver": "^7.3.5",
-        "validate-npm-package-name": "^4.0.0"
+        "validate-npm-package-name": "^7.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/npm-packlist": {
-      "version": "5.1.3",
+      "version": "10.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "glob": "^8.0.1",
-        "ignore-walk": "^5.0.1",
-        "npm-bundled": "^2.0.0",
-        "npm-normalize-package-bin": "^2.0.0"
-      },
-      "bin": {
-        "npm-packlist": "bin/index.js"
+        "ignore-walk": "^8.0.0",
+        "proc-log": "^6.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/npm-packlist/node_modules/npm-normalize-package-bin": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/npm-pick-manifest": {
-      "version": "7.0.2",
+      "version": "11.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "npm-install-checks": "^5.0.0",
-        "npm-normalize-package-bin": "^2.0.0",
-        "npm-package-arg": "^9.0.0",
+        "npm-install-checks": "^8.0.0",
+        "npm-normalize-package-bin": "^5.0.0",
+        "npm-package-arg": "^13.0.0",
         "semver": "^7.3.5"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/npm-pick-manifest/node_modules/npm-normalize-package-bin": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/npm-profile": {
-      "version": "6.2.1",
+      "version": "12.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "npm-registry-fetch": "^13.0.1",
-        "proc-log": "^2.0.0"
+        "npm-registry-fetch": "^19.0.0",
+        "proc-log": "^6.1.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/npm-registry-fetch": {
-      "version": "13.3.1",
+      "version": "19.1.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "make-fetch-happen": "^10.0.6",
-        "minipass": "^3.1.6",
-        "minipass-fetch": "^2.0.3",
-        "minipass-json-stream": "^1.0.1",
-        "minizlib": "^2.1.2",
-        "npm-package-arg": "^9.0.1",
-        "proc-log": "^2.0.0"
+        "@npmcli/redact": "^4.0.0",
+        "jsonparse": "^1.3.1",
+        "make-fetch-happen": "^15.0.0",
+        "minipass": "^7.0.2",
+        "minipass-fetch": "^5.0.0",
+        "minizlib": "^3.0.1",
+        "npm-package-arg": "^13.0.0",
+        "proc-log": "^6.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/npm-user-validate": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/npm/node_modules/npmlog": {
-      "version": "6.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "are-we-there-yet": "^3.0.0",
-        "console-control-strings": "^1.1.0",
-        "gauge": "^4.0.3",
-        "set-blocking": "^2.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/once": {
-      "version": "1.4.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "wrappy": "1"
-      }
-    },
-    "node_modules/npm/node_modules/opener": {
-      "version": "1.5.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "(WTFPL OR MIT)",
-      "bin": {
-        "opener": "bin/opener-bin.js"
-      }
-    },
-    "node_modules/npm/node_modules/p-map": {
       "version": "4.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "aggregate-error": "^3.0.0"
-      },
+      "license": "BSD-2-Clause",
       "engines": {
-        "node": ">=10"
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/p-map": {
+      "version": "7.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/npm/node_modules/pacote": {
-      "version": "13.6.2",
+      "version": "21.5.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/git": "^3.0.0",
-        "@npmcli/installed-package-contents": "^1.0.7",
-        "@npmcli/promise-spawn": "^3.0.0",
-        "@npmcli/run-script": "^4.1.0",
-        "cacache": "^16.0.0",
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.1.0",
-        "infer-owner": "^1.0.4",
-        "minipass": "^3.1.6",
-        "mkdirp": "^1.0.4",
-        "npm-package-arg": "^9.0.0",
-        "npm-packlist": "^5.1.0",
-        "npm-pick-manifest": "^7.0.0",
-        "npm-registry-fetch": "^13.0.1",
-        "proc-log": "^2.0.0",
-        "promise-retry": "^2.0.1",
-        "read-package-json": "^5.0.0",
-        "read-package-json-fast": "^2.0.3",
-        "rimraf": "^3.0.2",
-        "ssri": "^9.0.0",
-        "tar": "^6.1.11"
+        "@gar/promise-retry": "^1.0.0",
+        "@npmcli/git": "^7.0.0",
+        "@npmcli/installed-package-contents": "^4.0.0",
+        "@npmcli/package-json": "^7.0.0",
+        "@npmcli/promise-spawn": "^9.0.0",
+        "@npmcli/run-script": "^10.0.0",
+        "cacache": "^20.0.0",
+        "fs-minipass": "^3.0.0",
+        "minipass": "^7.0.2",
+        "npm-package-arg": "^13.0.0",
+        "npm-packlist": "^10.0.1",
+        "npm-pick-manifest": "^11.0.1",
+        "npm-registry-fetch": "^19.0.0",
+        "proc-log": "^6.0.0",
+        "sigstore": "^4.0.0",
+        "ssri": "^13.0.0",
+        "tar": "^7.4.3"
       },
       "bin": {
-        "pacote": "lib/bin.js"
+        "pacote": "bin/index.js"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/parse-conflict-json": {
-      "version": "2.0.2",
+      "version": "5.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "json-parse-even-better-errors": "^2.3.1",
-        "just-diff": "^5.0.1",
+        "json-parse-even-better-errors": "^5.0.0",
+        "just-diff": "^6.0.0",
         "just-diff-apply": "^5.2.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/npm/node_modules/path-is-absolute": {
-      "version": "1.0.1",
+    "node_modules/npm/node_modules/path-scurry": {
+      "version": "2.0.2",
       "dev": true,
       "inBundle": true,
-      "license": "MIT",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
       "engines": {
-        "node": ">=0.10.0"
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/npm/node_modules/postcss-selector-parser": {
-      "version": "6.0.10",
+      "version": "7.1.4",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -19089,12 +19166,21 @@
       }
     },
     "node_modules/npm/node_modules/proc-log": {
-      "version": "2.0.1",
+      "version": "6.1.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/proggy": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/promise-all-reject-late": {
@@ -19107,7 +19193,7 @@
       }
     },
     "node_modules/npm/node_modules/promise-call-limit": {
-      "version": "1.0.1",
+      "version": "3.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -19115,32 +19201,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/npm/node_modules/promise-inflight": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/promise-retry": {
-      "version": "2.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "err-code": "^2.0.2",
-        "retry": "^0.12.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/npm/node_modules/promzard": {
-      "version": "0.3.0",
+      "version": "3.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "read": "1"
+        "read": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/qrcode-terminal": {
@@ -19152,174 +19222,25 @@
       }
     },
     "node_modules/npm/node_modules/read": {
-      "version": "1.0.7",
+      "version": "5.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "mute-stream": "~0.0.4"
+        "mute-stream": "^3.0.0"
       },
       "engines": {
-        "node": ">=0.8"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/read-cmd-shim": {
-      "version": "3.0.0",
+      "version": "6.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
-    },
-    "node_modules/npm/node_modules/read-package-json": {
-      "version": "5.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^8.0.1",
-        "json-parse-even-better-errors": "^2.3.1",
-        "normalize-package-data": "^4.0.0",
-        "npm-normalize-package-bin": "^2.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/read-package-json-fast": {
-      "version": "2.0.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "json-parse-even-better-errors": "^2.3.0",
-        "npm-normalize-package-bin": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/read-package-json/node_modules/npm-normalize-package-bin": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/npm/node_modules/readdir-scoped-modules": {
-      "version": "1.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "debuglog": "^1.0.1",
-        "dezalgo": "^1.0.0",
-        "graceful-fs": "^4.1.2",
-        "once": "^1.3.0"
-      }
-    },
-    "node_modules/npm/node_modules/retry": {
-      "version": "0.12.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/npm/node_modules/rimraf": {
-      "version": "3.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/npm/node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/npm/node_modules/rimraf/node_modules/glob": {
-      "version": "7.2.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/npm/node_modules/rimraf/node_modules/minimatch": {
-      "version": "3.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/npm/node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "inBundle": true,
-      "license": "MIT"
     },
     "node_modules/npm/node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -19329,13 +19250,10 @@
       "optional": true
     },
     "node_modules/npm/node_modules/semver": {
-      "version": "7.3.7",
+      "version": "7.8.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -19343,29 +19261,34 @@
         "node": ">=10"
       }
     },
-    "node_modules/npm/node_modules/semver/node_modules/lru-cache": {
-      "version": "6.0.0",
+    "node_modules/npm/node_modules/signal-exit": {
+      "version": "4.1.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/npm/node_modules/set-blocking": {
-      "version": "2.0.0",
+    "node_modules/npm/node_modules/sigstore": {
+      "version": "4.1.1",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sigstore/bundle": "^4.0.0",
+        "@sigstore/core": "^3.2.1",
+        "@sigstore/protobuf-specs": "^0.5.0",
+        "@sigstore/sign": "^4.1.1",
+        "@sigstore/tuf": "^4.0.2",
+        "@sigstore/verify": "^3.1.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
     },
     "node_modules/npm/node_modules/smart-buffer": {
       "version": "4.2.0",
@@ -19378,51 +19301,41 @@
       }
     },
     "node_modules/npm/node_modules/socks": {
-      "version": "2.7.0",
+      "version": "2.8.9",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "ip": "^2.0.0",
+        "ip-address": "^10.1.1",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
-        "node": ">= 10.13.0",
+        "node": ">= 10.0.0",
         "npm": ">= 3.0.0"
       }
     },
     "node_modules/npm/node_modules/socks-proxy-agent": {
-      "version": "7.0.0",
+      "version": "8.0.5",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "agent-base": "^6.0.2",
-        "debug": "^4.3.3",
-        "socks": "^2.6.2"
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
       },
       "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/npm/node_modules/spdx-correct": {
-      "version": "3.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
+        "node": ">= 14"
       }
     },
     "node_modules/npm/node_modules/spdx-exceptions": {
-      "version": "2.3.0",
+      "version": "2.5.0",
       "dev": true,
       "inBundle": true,
       "license": "CC-BY-3.0"
     },
     "node_modules/npm/node_modules/spdx-expression-parse": {
-      "version": "3.0.1",
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -19432,85 +19345,49 @@
       }
     },
     "node_modules/npm/node_modules/spdx-license-ids": {
-      "version": "3.0.11",
+      "version": "3.0.23",
       "dev": true,
       "inBundle": true,
       "license": "CC0-1.0"
     },
     "node_modules/npm/node_modules/ssri": {
-      "version": "9.0.1",
+      "version": "13.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "minipass": "^3.1.1"
+        "minipass": "^7.0.3"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/string_decoder": {
-      "version": "1.3.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
-    "node_modules/npm/node_modules/string-width": {
-      "version": "4.2.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/supports-color": {
-      "version": "7.2.0",
+      "version": "10.2.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/npm/node_modules/tar": {
-      "version": "6.1.11",
+      "version": "7.5.19",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^3.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
       },
       "engines": {
-        "node": ">= 10"
+        "node": ">=18"
       }
     },
     "node_modules/npm/node_modules/text-table": {
@@ -19520,42 +19397,86 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/tiny-relative-date": {
-      "version": "1.3.0",
+      "version": "2.0.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/npm/node_modules/treeverse": {
-      "version": "2.0.0",
+    "node_modules/npm/node_modules/tinyglobby": {
+      "version": "0.2.17",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/unique-filename": {
-      "version": "2.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
-        "unique-slug": "^3.0.0"
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "node_modules/npm/node_modules/unique-slug": {
+    "node_modules/npm/node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/npm/node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/npm/node_modules/treeverse": {
       "version": "3.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/tuf-js": {
+      "version": "4.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
       "dependencies": {
-        "imurmurhash": "^0.1.4"
+        "@tufjs/models": "4.1.0",
+        "debug": "^4.4.3",
+        "make-fetch-happen": "^15.0.1"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/undici": {
+      "version": "6.27.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/npm/node_modules/util-deprecate": {
@@ -19564,91 +19485,59 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/npm/node_modules/validate-npm-package-license": {
-      "version": "3.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
-      }
-    },
     "node_modules/npm/node_modules/validate-npm-package-name": {
-      "version": "4.0.0",
+      "version": "7.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "dependencies": {
-        "builtins": "^5.0.0"
-      },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/walk-up-path": {
-      "version": "1.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/wcwidth": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "defaults": "^1.0.3"
-      }
-    },
-    "node_modules/npm/node_modules/which": {
-      "version": "2.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/npm/node_modules/wide-align": {
-      "version": "1.1.5",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^1.0.2 || 2 || 3 || 4"
-      }
-    },
-    "node_modules/npm/node_modules/wrappy": {
-      "version": "1.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/write-file-atomic": {
-      "version": "4.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "imurmurhash": "^0.1.4",
-        "signal-exit": "^3.0.7"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/yallist": {
       "version": "4.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/npm/node_modules/which": {
+      "version": "6.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^4.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/write-file-atomic": {
+      "version": "7.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/yallist": {
+      "version": "5.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/number-allocator": {
       "version": "1.0.14",
@@ -20103,6 +19992,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/path-exists": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
@@ -20367,6 +20269,22 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/pretty-ms": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/proc-log": {
@@ -22216,6 +22134,19 @@
         "url": "https://opencollective.com/synckit"
       }
     },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tar-stream": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
@@ -22249,43 +22180,55 @@
       }
     },
     "node_modules/temp-dir": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
-      "integrity": "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
+      "integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=14.16"
       }
     },
     "node_modules/tempy": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tempy/-/tempy-1.0.1.tgz",
-      "integrity": "sha512-biM9brNqxSc04Ee71hzFbryD11nX7VPhQQY32AdDmjFvodsRFz/3ufeoTZ6uYkRFfGo188tENcASNs3vTdsM0w==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tempy/-/tempy-3.2.0.tgz",
+      "integrity": "sha512-d79HhZya5Djd7am0q+W4RTsSU+D/aJzM+4Y4AGJGuGlgM2L6sx5ZvOYTmZjqPhrDrV6xJTtRSm1JCLj6V6LHLQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "del": "^6.0.0",
-        "is-stream": "^2.0.0",
-        "temp-dir": "^2.0.0",
-        "type-fest": "^0.16.0",
-        "unique-string": "^2.0.0"
+        "is-stream": "^3.0.0",
+        "temp-dir": "^3.0.0",
+        "type-fest": "^2.12.2",
+        "unique-string": "^3.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tempy/node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tempy/node_modules/type-fest": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.16.0.tgz",
-      "integrity": "sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==",
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
-        "node": ">=10"
+        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -22632,6 +22575,16 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
     "node_modules/type": {
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/type/-/type-2.7.3.tgz",
@@ -22709,6 +22662,16 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/undici": {
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
@@ -22773,16 +22736,19 @@
       }
     },
     "node_modules/unique-string": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
-      "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
+      "integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "crypto-random-string": "^2.0.0"
+        "crypto-random-string": "^4.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/universal-user-agent": {
@@ -23199,6 +23165,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.2.0.tgz",
+      "integrity": "sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "scripts": {
     "build": "nx run-many --verbose --target=build",
     "create:sample": "./scripts/create-sample.sh",
+    "tp:list": "node -r @swc-node/register scripts/trusted-publishing/tp.ts list",
+    "tp:check": "node -r @swc-node/register scripts/trusted-publishing/tp.ts check",
+    "tp:normalize": "node -r @swc-node/register scripts/trusted-publishing/tp.ts normalize",
+    "tp:trust": "node -r @swc-node/register scripts/trusted-publishing/tp.ts trust",
     "install-hooks": "pre-commit install -t commit-msg -t pre-commit",
     "postinstall": "[[ -z \"$CI\" ]] && npm run install-hooks || echo 'Skipping postinstall in CI'"
   },
@@ -55,6 +59,7 @@
     "aws-iot-device-sdk-v2": "^1.27.0",
     "form-data": "^4.0.6",
     "uuid": "^14.0.0",
-    "babel-plugin-macros": "^3.1.0"
+    "babel-plugin-macros": "^3.1.0",
+    "@semantic-release/npm": "^13.1.0"
   }
 }

--- a/scripts/trusted-publishing/README.md
+++ b/scripts/trusted-publishing/README.md
@@ -1,0 +1,146 @@
+# npm Trusted Publishing automation
+
+This repo publishes all `@affinidi-tdk/*` npm packages from CI using **npm
+trusted publishing (OIDC)** — no long-lived `NPM_TOKEN`. Publishes use
+short-lived, workflow-scoped credentials and get automatic provenance.
+
+`scripts/trusted-publishing/tp.ts` discovers every npm package published via
+semantic-release and keeps them configured. Because it is discovery-driven,
+**new packages are handled automatically** — just add your package with a
+`semantic-release` target and run the commands below.
+
+## Commands
+
+```bash
+npm run tp:list        # show all discovered npm packages + classification
+npm run tp:check       # CI guard: fail if any package isn't OIDC-ready
+npm run tp:normalize   # fix plain-TS packages to the OIDC-ready publish config
+npm run tp:trust       # register each package as a Trusted Publisher on npmjs.com
+```
+
+Useful flags: `--only <pkg>` (repeatable), `--dry-run`, `--json`, and
+`--stage` (trust: grant stage-only publish instead of direct publish).
+Config is overridable via env: `TP_REPO`, `TP_WORKFLOW`, `TP_ENVIRONMENT`,
+`TP_REGISTRY`, `TP_PERMISSION`, `TP_NPM` (path to the npm binary used by `trust`).
+`tp:trust` requires **npm >= 12** (permission flags); the other commands work on any npm.
+
+## How it works
+
+- **Plain-TS packages** publish via `@semantic-release/npm`. OIDC support requires
+  `@semantic-release/npm >= 13.1.0`, pinned via an `overrides` entry in the root
+  `package.json` (it stays peer-compatible with the `semantic-release@20`
+  bundled by `@theunderscorer/nx-semantic-release`). `verifyConditions` skips the
+  token check automatically when an OIDC context is present.
+- **jsii packages** publish via `publib`. Setting `NPM_TRUSTED_PUBLISHER=true`
+  in the release workflow makes publib use OIDC instead of `NPM_TOKEN`.
+- The release workflow (`.github/workflows/nx-release.yaml`) runs on Node 24
+  (npm >= 11.5.1, required for OIDC) with `id-token: write`, and no longer
+  passes `NPM_TOKEN`/`NODE_AUTH_TOKEN`.
+- `tp:check` runs on every PR (`nx-branch.yaml`) so a new package that isn't
+  OIDC-ready fails CI.
+
+## One-time registration (per package, on npmjs.com)
+
+`npm trust` writes the trusted-publisher config on npmjs.com. It must be run by
+an npm **org owner**, requires **2FA**, and needs **npm >= 12** (the CLI added
+the `--allow-publish`/`--allow-stage-publish` permission flags in 12.0.0; older
+npm silently omits them and the registry rejects the request). Run once
+(idempotent):
+
+```bash
+npm i -g npm@latest       # ensure your npm is >= 12 (check with: npm -v)
+npm login                 # as an @affinidi-tdk owner
+npm run tp:trust          # registers every package with `publish` permission
+# preview first if you like:
+npm run tp:trust -- --dry-run
+npm logout                # IMPORTANT: revoke the login token afterwards
+```
+
+Each package is registered with:
+`repository=affinidi/affinidi-tdk`, `file=nx-release.yaml`, `environment=main`,
+`permission=publish` (CI may `npm publish` directly, matching our auto-release
+from `main`).
+
+**About 2FA:** `npm trust` is a write operation, so npm requires two-factor
+authentication. The script runs npm with an inherited terminal, so just complete
+npm's prompt when it appears (it prints a `https://www.npmjs.com/auth/...` URL —
+open it, approve, and it continues). You'll be prompted per package. To script a
+single package non-interactively, pass a fresh code:
+`npm run tp:trust -- --only @affinidi-tdk/<name> --otp 123456` (OTP codes expire
+in ~30s, so `--otp` is only practical with `--only`). Any packages that fail
+(e.g. a cancelled/expired OTP) are listed at the end with a ready-to-run
+re-invocation; already-configured packages are skipped, so re-running is safe.
+
+> **Which npm is used?** `@semantic-release/npm` vendors an older `npm` under
+> `node_modules/.bin`, which `npm run` puts first on `PATH`. The script
+> deliberately ignores that copy and invokes the npm that launched `npm run`
+> (via `npm_execpath`), i.e. **your global npm** — so you only need *your* npm to
+> be >= 12, not the vendored one. It prints which npm it resolved
+> (`Using npm <version> (<path>)`). If it still picks the wrong one, force it:
+> `TP_NPM=$(command -v npm) npm run tp:trust`.
+
+**Stage-only (max security, optional):** run `npm run tp:trust -- --stage` to
+grant `stage publish` instead. CI then only *stages* a release and a maintainer
+must promote it with 2FA (via the CLI or npmjs.com) before it goes public. This
+changes the release flow (publishes no longer happen automatically on merge), so
+only use it if you want mandatory human approval per release.
+
+### Log out when you're done (important)
+
+`npm login` writes a long-lived access token to your `~/.npmrc`
+(`//registry.npmjs.org/:_authToken=…`). Registration is a **one-time** action,
+so once `tp:trust` succeeds you should immediately remove that credential —
+leaving it lying around re-introduces exactly the kind of standing token that
+trusted publishing exists to eliminate.
+
+```bash
+npm logout                                  # invalidates the token server-side and clears ~/.npmrc
+npm whoami                                  # should now error: "This command requires you to be logged in"
+```
+
+Notes:
+- `npm logout` both **revokes the token on npmjs.com** and removes it from your
+  `~/.npmrc`, so a leaked copy of the file is useless afterwards.
+- If you authenticated against a non-default registry, log out of that same one:
+  `npm logout --registry https://registry.npmjs.org`.
+- If `~/.npmrc` still contains an `_authToken` line after logout (e.g. it was
+  set manually), delete that line by hand.
+- CI never logs in or out — it publishes via short-lived OIDC tokens, so this
+  applies only to the human running the one-time registration.
+
+## Block token publishing (required hardening)
+
+**Configuring a trusted publisher does *not* disable tokens on its own** — npm
+accepts OIDC publishes *in addition to* token-based publishes. To make OIDC the
+*only* way to publish (so a leaked/legacy `NPM_TOKEN` can't push a release), you
+must, per package, on npmjs.com:
+
+1. Package → **Settings** → **Publishing access**
+2. Select **"Require two-factor authentication and disallow tokens"**
+3. **Update Package Settings**
+
+This is a **web-UI-only** setting — npm exposes no CLI or registry API for it
+(`npm access` can only set `status`/`mfa`, and `mfa=automation` actually *lets*
+automation tokens bypass 2FA). Trusted publishers keep working after this,
+because they authenticate with OIDC, not tokens. Do this only **after** you've
+verified an OIDC publish succeeds, then revoke the old `NPM_TOKEN`.
+
+## Recommended rollout
+
+1. Merge this PR (workflow + config + override).
+2. Run `npm run tp:trust` as an org owner (npm >= 12) to register all packages,
+   then `npm logout` to revoke the login token.
+3. Trigger a release and confirm packages publish via OIDC (provenance badge appears).
+4. Harden per package on npmjs.com: **"Require two-factor authentication and
+   disallow tokens"** (see above), then revoke the old `NPM_TOKEN` automation token.
+
+## Adding a new package later
+
+1. Add the package with a `semantic-release` target (plain-TS: use the
+   `@semantic-release/npm` plugin; jsii: use publib `publish-npm`).
+2. `npm run tp:normalize` (fixes plain-TS config if needed) and commit.
+3. `npm run tp:trust -- --only @affinidi-tdk/<name>` as an org owner, then
+   `npm logout`.
+4. On npmjs.com, set the new package to **"Require 2FA and disallow tokens"**.
+
+CI (`tp:check`) will fail the PR until the package's repo config is OIDC-ready.

--- a/scripts/trusted-publishing/tp.ts
+++ b/scripts/trusted-publishing/tp.ts
@@ -1,0 +1,515 @@
+#!/usr/bin/env ts-node
+/**
+ * Trusted-publishing automation for all npm packages in this monorepo.
+ *
+ * Discovers every npm package that is published via semantic-release and lets
+ * you keep its publish config OIDC-ready and register it as an npm Trusted
+ * Publisher (npmjs.com) - so both existing and NEW packages are handled
+ * automatically without hand-editing each project.
+ *
+ * Subcommands:
+ *   list        Show discovered npm packages + classification.
+ *   check       CI guard: fail if any npm package is not OIDC-ready
+ *               (wrong publish config, or a token still wired in the workflow).
+ *   normalize   Rewrite plain-TS packages to the OIDC-ready
+ *               @semantic-release/npm flow (idempotent). jsii packages are
+ *               left as publib and rely on NPM_TRUSTED_PUBLISHER in CI.
+ *   trust       Register each package as a GitHub Actions Trusted Publisher on
+ *               npmjs.com via `npm trust github` (idempotent). Grants the
+ *               `publish` permission by default (use --stage for stage-only).
+ *               Requires an authenticated npm session with owner rights and
+ *               npm >= 12 (run once).
+ *
+ * Flags:
+ *   --only <pkg>     Restrict to a single package name (repeatable).
+ *   --dry-run        Show what would change / run, without doing it.
+ *   --json           Machine-readable output (list/check).
+ *   --stage          trust: grant stage-only publish (maintainer promotes with 2FA).
+ *   --otp <code>     trust: pass a 2FA one-time password to npm (best with --only;
+ *                    otherwise complete npm's interactive/web 2FA when prompted).
+ *
+ * Config (overridable via env):
+ *   TP_REPO         default: affinidi/affinidi-tdk
+ *   TP_WORKFLOW     default: nx-release.yaml   (basename inside .github/workflows)
+ *   TP_ENVIRONMENT  default: main
+ *   TP_REGISTRY     default: https://registry.npmjs.org
+ *   TP_PERMISSION   default: allow-publish  (or allow-stage-publish)
+ *
+ * The `trust` subcommand requires npm CLI >= 12.0.0 (permission flags).
+ */
+
+import {
+  readFileSync,
+  writeFileSync,
+  readdirSync,
+  statSync,
+  existsSync,
+} from 'node:fs';
+import { join, dirname, relative } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+type SrPlugin = string | [string, Record<string, unknown>];
+
+interface Project {
+  targets?: Record<string, { options?: { plugins?: SrPlugin[]; npm?: unknown } }>;
+}
+
+type Method = 'semantic-release-npm' | 'publib';
+
+interface NpmPackage {
+  name: string;
+  dir: string;
+  projectPath: string;
+  pkgPath: string;
+  isJsii: boolean;
+  method: Method;
+  npmPublishDisabled: boolean;
+  npmOption: unknown;
+  usesNpmPlugin: boolean;
+  execPublishCmd: string | null;
+  project: Project;
+}
+
+interface Flags {
+  only: string[];
+  dryRun: boolean;
+  json: boolean;
+  stage: boolean;
+  otp?: string;
+}
+
+const REPO_ROOT = join(__dirname, '..', '..');
+// Permission granted to the trusted publisher (npm >= 12):
+//   allow-publish       -> CI may `npm publish` directly (matches our auto-release from main)
+//   allow-stage-publish -> CI may only stage; a maintainer promotes with 2FA (max security)
+type Permission = 'allow-publish' | 'allow-stage-publish';
+const CFG = {
+  repo: process.env.TP_REPO || 'affinidi/affinidi-tdk',
+  workflow: process.env.TP_WORKFLOW || 'nx-release.yaml',
+  environment: process.env.TP_ENVIRONMENT || 'main',
+  registry: process.env.TP_REGISTRY || 'https://registry.npmjs.org',
+  permission: (process.env.TP_PERMISSION as Permission) || 'allow-publish',
+};
+// npm added the trust permission flags in 12.0.0; older CLIs silently omit them
+// and the registry rejects the request.
+const MIN_NPM_FOR_TRUST = '12.0.0';
+const WORKFLOW_PATH = join(REPO_ROOT, '.github', 'workflows', CFG.workflow);
+const SKIP_DIRS = new Set(['node_modules', 'dist', '.git', '.nx', 'coverage', 'tmp']);
+
+function fail(msg: string): never {
+  console.error(`\u001b[31merror:\u001b[0m ${msg}`);
+  process.exit(1);
+}
+
+function readJson<T = any>(p: string): T {
+  return JSON.parse(readFileSync(p, 'utf8')) as T;
+}
+
+function pluginId(pl: SrPlugin): string {
+  return Array.isArray(pl) ? pl[0] : pl;
+}
+
+/** Recursively find every project.json under the repo (skipping build/vendor dirs). */
+function findProjectFiles(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (SKIP_DIRS.has(entry)) continue;
+    const full = join(dir, entry);
+    let isDir: boolean;
+    try {
+      isDir = statSync(full).isDirectory();
+    } catch {
+      continue;
+    }
+    if (isDir) findProjectFiles(full, out);
+    else if (entry === 'project.json') out.push(full);
+  }
+  return out;
+}
+
+/**
+ * Classify a project as an npm package (or not).
+ * npm packages have a sibling package.json AND publish to npm via
+ * @semantic-release/npm (plain-TS) or a publib `publish-npm` exec (jsii).
+ */
+function classify(projectPath: string): NpmPackage | null {
+  let project: Project;
+  try {
+    project = readJson<Project>(projectPath);
+  } catch {
+    return null;
+  }
+  const sr = project.targets?.['semantic-release'];
+  if (!sr) return null; // not published at all
+
+  const dir = dirname(projectPath);
+  const pkgPath = join(dir, 'package.json');
+  if (!existsSync(pkgPath)) return null; // python/java projects have no package.json
+
+  let pkg: any;
+  try {
+    pkg = readJson(pkgPath);
+  } catch {
+    return null;
+  }
+  if (!pkg.name) return null;
+
+  const opts = sr.options || {};
+  const plugins: SrPlugin[] = opts.plugins || [];
+  let usesNpmPlugin = false;
+  let npmPublishDisabled = false;
+  let execPublishCmd: string | null = null;
+  for (const pl of plugins) {
+    const id = pluginId(pl);
+    if (id === '@semantic-release/npm') {
+      usesNpmPlugin = true;
+      if (Array.isArray(pl) && (pl[1] as any)?.npmPublish === false) npmPublishDisabled = true;
+    }
+    if (Array.isArray(pl) && pl[0] === '@semantic-release/exec') {
+      execPublishCmd = ((pl[1] as any)?.publishCmd as string) || null;
+    }
+  }
+  const publishesNpm = usesNpmPlugin || (!!execPublishCmd && /publish-npm/.test(execPublishCmd));
+  if (!publishesNpm) return null; // pypi / maven only
+
+  const isJsii = 'jsii' in pkg || /jsii/.test(pkg.scripts?.build || '');
+  const method: Method = usesNpmPlugin ? 'semantic-release-npm' : 'publib';
+
+  return {
+    name: pkg.name,
+    dir: relative(REPO_ROOT, dir),
+    projectPath,
+    pkgPath,
+    isJsii,
+    method,
+    npmPublishDisabled,
+    npmOption: opts.npm,
+    usesNpmPlugin,
+    execPublishCmd,
+    project,
+  };
+}
+
+function discover(): NpmPackage[] {
+  const pkgs: NpmPackage[] = [];
+  for (const pf of findProjectFiles(REPO_ROOT)) {
+    const c = classify(pf);
+    if (c) pkgs.push(c);
+  }
+  pkgs.sort((a, b) => a.name.localeCompare(b.name));
+  return pkgs;
+}
+
+function applyOnly(pkgs: NpmPackage[], only: string[]): NpmPackage[] {
+  if (!only.length) return pkgs;
+  const set = new Set(only);
+  const filtered = pkgs.filter((p) => set.has(p.name));
+  const missing = only.filter((n) => !filtered.some((p) => p.name === n));
+  if (missing.length) fail(`--only package(s) not found: ${missing.join(', ')}`);
+  return filtered;
+}
+
+/* ------------------------------- list ---------------------------------- */
+function cmdList(pkgs: NpmPackage[], flags: Flags): void {
+  if (flags.json) {
+    console.log(JSON.stringify(pkgs.map(({ project, ...rest }) => rest), null, 2));
+    return;
+  }
+  console.log(`Discovered ${pkgs.length} npm package(s) published via semantic-release:\n`);
+  const w = Math.max(...pkgs.map((p) => p.name.length));
+  for (const p of pkgs) {
+    const kind = p.isJsii ? 'jsii  ' : 'ts    ';
+    console.log(`  ${p.name.padEnd(w)}  ${kind}  via ${p.method.padEnd(20)}  ${p.dir}`);
+  }
+  console.log(
+    `\nTrusted publisher target: repo=${CFG.repo} workflow=${CFG.workflow} env=${CFG.environment}`,
+  );
+}
+
+/* ------------------------------- check --------------------------------- */
+function workflowText(): string {
+  if (!existsSync(WORKFLOW_PATH)) fail(`release workflow not found: ${WORKFLOW_PATH}`);
+  return readFileSync(WORKFLOW_PATH, 'utf8');
+}
+
+function cmdCheck(pkgs: NpmPackage[], flags: Flags): void {
+  const problems: string[] = [];
+  const wf = workflowText();
+
+  // Workflow-level guards (apply to every npm package).
+  if (!/id-token:\s*write/.test(wf)) {
+    problems.push(`[workflow] ${CFG.workflow} is missing "id-token: write" (required for OIDC).`);
+  }
+  if (
+    /NODE_AUTH_TOKEN:\s*\$\{\{\s*secrets\.NPM_TOKEN/.test(wf) ||
+    /^\s*NPM_TOKEN:\s*\$\{\{\s*secrets\.NPM_TOKEN/m.test(wf)
+  ) {
+    problems.push(
+      `[workflow] ${CFG.workflow} still wires NPM_TOKEN/NODE_AUTH_TOKEN into the release step; remove it to use trusted publishing.`,
+    );
+  }
+  const hasJsii = pkgs.some((p) => p.method === 'publib');
+  if (hasJsii && !/NPM_TRUSTED_PUBLISHER/.test(wf)) {
+    problems.push(
+      `[workflow] jsii packages use publib but ${CFG.workflow} does not set NPM_TRUSTED_PUBLISHER=true.`,
+    );
+  }
+
+  // Per-package config guards.
+  for (const p of pkgs) {
+    if (p.method === 'semantic-release-npm') {
+      if (!p.usesNpmPlugin) {
+        problems.push(`[${p.name}] missing an explicit @semantic-release/npm plugin.`);
+      }
+      if (p.npmPublishDisabled) {
+        problems.push(`[${p.name}] @semantic-release/npm has npmPublish:false, so nothing is published to npm.`);
+      }
+      if (p.execPublishCmd && /publish-npm/.test(p.execPublishCmd)) {
+        problems.push(`[${p.name}] mixes @semantic-release/npm with a publib exec publish-npm; pick one.`);
+      }
+    }
+  }
+
+  if (flags.json) {
+    console.log(JSON.stringify({ ok: problems.length === 0, problems }, null, 2));
+  } else if (problems.length) {
+    console.error(`\u001b[31mTrusted-publishing check failed (${problems.length}):\u001b[0m`);
+    for (const pr of problems) console.error(`  - ${pr}`);
+  } else {
+    console.log(`\u001b[32mOK\u001b[0m - all ${pkgs.length} npm package(s) are OIDC-ready.`);
+  }
+  if (problems.length) process.exit(1);
+}
+
+/* ----------------------------- normalize ------------------------------- */
+function cmdNormalize(pkgs: NpmPackage[], flags: Flags): void {
+  let changed = 0;
+  for (const p of pkgs) {
+    if (p.isJsii && p.method === 'publib') continue; // jsii/publib keeps its flow; OIDC via env var
+    const sr = p.project.targets!['semantic-release'];
+    const opts = (sr.options = sr.options || {});
+    let mutated = false;
+
+    // Remove any publib exec that publishes npm (conflicts with the npm plugin).
+    const plugins: SrPlugin[] = Array.isArray(opts.plugins) ? opts.plugins : [];
+    const cleaned = plugins.filter((pl) => {
+      if (Array.isArray(pl) && pl[0] === '@semantic-release/exec') {
+        return !/publish-npm/.test(((pl[1] as any)?.publishCmd as string) || '');
+      }
+      return true;
+    });
+    if (cleaned.length !== plugins.length) mutated = true;
+
+    // Ensure an explicit @semantic-release/npm plugin with npmPublish enabled.
+    const npmIdx = cleaned.findIndex((pl) => pluginId(pl) === '@semantic-release/npm');
+    if (npmIdx === -1) {
+      cleaned.push(['@semantic-release/npm', { npmPublish: true }]);
+      mutated = true;
+    } else {
+      const entry = cleaned[npmIdx];
+      if (Array.isArray(entry) && (entry[1] as any)?.npmPublish === false) {
+        (entry[1] as any).npmPublish = true;
+        mutated = true;
+      }
+    }
+    opts.plugins = cleaned;
+    // Note: the nx-semantic-release `npm` option is left untouched on purpose -
+    // packages may set it false while configuring the plugin manually.
+
+    if (mutated) {
+      changed++;
+      if (flags.dryRun) {
+        console.log(`would normalize ${p.name} (${p.projectPath})`);
+      } else {
+        writeFileSync(p.projectPath, JSON.stringify(p.project, null, 2) + '\n');
+        console.log(`normalized ${p.name}`);
+      }
+    }
+  }
+  console.log(
+    changed === 0
+      ? 'Nothing to normalize - all plain-TS packages already OIDC-ready.'
+      : `${flags.dryRun ? 'Would normalize' : 'Normalized'} ${changed} package(s).`,
+  );
+}
+
+/* ------------------------------- trust --------------------------------- */
+/**
+ * Resolve which npm to invoke. Running under `npm run` prepends
+ * `node_modules/.bin` to PATH, and `@semantic-release/npm` vendors its own
+ * (older) `npm` there - so a bare `spawnSync('npm')` would hit that nested copy
+ * instead of the user's real CLI. Prefer, in order:
+ *   1. $TP_NPM                       (explicit override)
+ *   2. $npm_execpath                 (the outer npm that launched `npm run`)
+ *   3. `npm` from a PATH with node_modules/.bin stripped
+ */
+function resolveNpm(): { cmd: string; prefix: string[]; env: NodeJS.ProcessEnv } {
+  const env = { ...process.env };
+  // Strip any node_modules/.bin entries so a fallback PATH lookup can't hit the
+  // vendored npm.
+  if (env.PATH) {
+    env.PATH = env.PATH.split(':')
+      .filter((p) => !/[\\/]node_modules[\\/]\.bin$/.test(p))
+      .join(':');
+  }
+  if (process.env.TP_NPM) return { cmd: process.env.TP_NPM, prefix: [], env };
+  const execpath = process.env.npm_execpath;
+  if (execpath && /\.[cm]?js$/.test(execpath)) {
+    return { cmd: process.execPath, prefix: [execpath], env };
+  }
+  if (execpath) return { cmd: execpath, prefix: [], env };
+  return { cmd: 'npm', prefix: [], env };
+}
+
+const NPM = resolveNpm();
+
+function npm(args: string[], { capture = false }: { capture?: boolean } = {}) {
+  return spawnSync(NPM.cmd, [...NPM.prefix, ...args], {
+    encoding: 'utf8',
+    env: NPM.env,
+    stdio: capture ? ['ignore', 'pipe', 'pipe'] : 'inherit',
+  });
+}
+
+/** Compare dotted versions: returns true if a >= b. */
+function gte(a: string, b: string): boolean {
+  const pa = a.split('.').map((n) => parseInt(n, 10) || 0);
+  const pb = b.split('.').map((n) => parseInt(n, 10) || 0);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const x = pa[i] || 0;
+    const y = pb[i] || 0;
+    if (x !== y) return x > y;
+  }
+  return true;
+}
+
+function alreadyTrusted(name: string): boolean {
+  const res = npm(['trust', 'list', name, '--json', '--registry', CFG.registry], { capture: true });
+  if (res.status !== 0) return false;
+  let data: any;
+  try {
+    data = JSON.parse(res.stdout || '[]');
+  } catch {
+    return false;
+  }
+  const list: unknown[] = Array.isArray(data)
+    ? data
+    : data?.trustedPublishers || data?.publishers || [];
+  return list.some((t) => {
+    const s = JSON.stringify(t).toLowerCase();
+    return (
+      s.includes(CFG.repo.toLowerCase()) &&
+      s.includes(CFG.workflow.toLowerCase()) &&
+      (!CFG.environment || s.includes(CFG.environment.toLowerCase()))
+    );
+  });
+}
+
+function cmdTrust(pkgs: NpmPackage[], flags: Flags): void {
+  const which = NPM.prefix[0] || NPM.cmd;
+  const verify = npm(['trust', '--help'], { capture: true });
+  if (verify.status !== 0 && !/trust/.test(verify.stderr || '')) {
+    fail(`this npm CLI has no \`npm trust\` command; upgrade to npm >= ${MIN_NPM_FOR_TRUST} (npm i -g npm@latest).`);
+  }
+  const npmVer = (npm(['-v'], { capture: true }).stdout || '').trim();
+  if (npmVer && !gte(npmVer, MIN_NPM_FOR_TRUST)) {
+    fail(
+      `npm ${npmVer} (${which}) is too old to register trusted publishers - the permission flags ` +
+        `(--allow-publish/--allow-stage-publish) require npm >= ${MIN_NPM_FOR_TRUST}.\n` +
+        `  Upgrade your npm (npm i -g npm@latest), or point TP_NPM at an npm >= ${MIN_NPM_FOR_TRUST}:\n` +
+        `    TP_NPM=$(command -v npm) npm run tp:trust`,
+    );
+  }
+  console.log(`Using npm ${npmVer} (${which}).`);
+
+  const permission: Permission = flags.stage ? 'allow-stage-publish' : CFG.permission;
+  console.log(
+    `Registering trusted publisher with permission: ${permission === 'allow-stage-publish' ? 'stage publish (maintainer promotes with 2FA)' : 'publish'}\n`,
+  );
+
+  let done = 0;
+  let skipped = 0;
+  const failed: string[] = [];
+  for (const p of pkgs) {
+    if (!flags.dryRun && alreadyTrusted(p.name)) {
+      console.log(`= ${p.name} already has this trusted publisher, skipping`);
+      skipped++;
+      continue;
+    }
+    const args = [
+      'trust',
+      'github',
+      p.name,
+      '--file',
+      CFG.workflow,
+      '--repo',
+      CFG.repo,
+      '--environment',
+      CFG.environment,
+      `--${permission}`,
+      '--registry',
+      CFG.registry,
+      '-y',
+    ];
+    if (flags.otp) args.push('--otp', flags.otp);
+    if (flags.dryRun) args.push('--dry-run');
+    console.log(`\n\u001b[36m$ npm ${args.join(' ')}\u001b[0m`);
+    // Inherit stdio so npm's interactive 2FA (one-time password / web auth) works.
+    const res = npm(args);
+    if (res.status === 0) {
+      done++;
+    } else {
+      failed.push(p.name);
+      console.error(`\u001b[31m! failed to configure ${p.name}\u001b[0m`);
+    }
+  }
+  console.log(
+    `\nTrusted publishing: configured ${done}, skipped ${skipped}, failed ${failed.length}, total ${pkgs.length}.`,
+  );
+  if (failed.length) {
+    console.error(
+      `\nThe following package(s) were not configured:\n  ${failed.join('\n  ')}\n` +
+        `Re-run for just those, e.g.:\n  npm run tp:trust -- ${failed.map((n) => `--only ${n}`).join(' ')}`,
+    );
+    process.exit(1);
+  }
+}
+
+/* ------------------------------- main ---------------------------------- */
+function parseArgs(argv: string[]): { cmd: string | undefined; flags: Flags } {
+  const flags: Flags = { only: [], dryRun: false, json: false, stage: false };
+  const rest: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--only') flags.only.push(argv[++i]);
+    else if (a === '--dry-run') flags.dryRun = true;
+    else if (a === '--json') flags.json = true;
+    else if (a === '--stage' || a === '--stage-only') flags.stage = true;
+    else if (a === '--otp') flags.otp = argv[++i];
+    else rest.push(a);
+  }
+  return { cmd: rest[0], flags };
+}
+
+function main(): void {
+  const { cmd, flags } = parseArgs(process.argv.slice(2));
+  const all = discover();
+  const pkgs = applyOnly(all, flags.only);
+
+  switch (cmd) {
+    case 'list':
+      return cmdList(pkgs, flags);
+    case 'check':
+      return cmdCheck(pkgs, flags);
+    case 'normalize':
+      return cmdNormalize(pkgs, flags);
+    case 'trust':
+      return cmdTrust(pkgs, flags);
+    default:
+      console.log(
+        'usage: node -r @swc-node/register scripts/trusted-publishing/tp.ts <list|check|normalize|trust> [--only <pkg>] [--dry-run] [--json] [--stage]',
+      );
+      process.exit(cmd ? 1 : 0);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary

Migrate all `@affinidi-tdk` npm packages to **npm trusted publishing (OIDC)**, removing the need for a long-lived `NPM_TOKEN` in CI. Also standardises all CI pipelines on **Node 24**.

## What changed

- **OIDC publishing for plain-TS packages** — override `@semantic-release/npm` to `^13.1.0` (first release with OIDC support) while staying peer-compatible with the existing `semantic-release@20` toolchain.
- **OIDC publishing for jsii/publib packages** — set `NPM_TRUSTED_PUBLISHER=true` in the release workflow.
- **Release workflow hardening** — run on Node 24 (npm ≥ 11.5.1), add `id-token: write`, and drop `NPM_TOKEN` / `NODE_AUTH_TOKEN`.
- **Node 24 everywhere** — all three CI workflows now use `node-version: 24`.
- **Discovery-driven automation** — new `scripts/trusted-publishing/tp.ts` with four modes:
  - `tp:list` — list every publishable npm package
  - `tp:check` — fail if any package isn't OIDC-ready (wired into PR CI)
  - `tp:normalize` — make a package OIDC-ready
  - `tp:trust` — register trusted publishers on npm (requires npm ≥ 12 + 2FA)
- **Docs** — `scripts/trusted-publishing/README.md` covers the rollout, adding new packages, 2FA/`--otp`, correct one-time logout, and the required per-package token-blocking hardening.

## Manual npm-owner steps — ✅ already completed

The following one-time steps (which can't be done from CI) have **already been performed** on npmjs.com:

- [x] Registered trusted publishers for all packages (`npm run tp:trust`).
- [x] Verified a release publishes successfully via OIDC.
- [x] Per package: enabled **"Require two-factor authentication and disallow tokens"** (Settings → Publishing access) so token-based publishing is blocked.
- [x] Revoked the old `NPM_TOKEN` secret.

> **Merge note:** because `NPM_TOKEN` is already revoked and tokens are now disallowed on npm, releasing from `main` depends on this PR — once merged, CI publishes via OIDC. Any release attempted before merge would fail on the old token path, so this should be merged before the next release.

## Notes

- `engines.node` minimums are intentionally **left unchanged** in this PR.
- `tp:trust` is safe to re-run: it skips already-configured packages and collects failures instead of aborting.
