### PR TITLE
ci: drop registry-url from setup-node to remove always-auth warning

### DIFF
--- a/.github/workflows/nx-release.yaml
+++ b/.github/workflows/nx-release.yaml
@@ -39,8 +39,6 @@ jobs:
           # npm trusted publishing (OIDC) requires npm CLI >= 11.5.1, which ships with Node 24.
           node-version: 24
           cache: 'npm'
-          registry-url: 'https://registry.npmjs.org'
-          scope: '@affinidi-tdk'
 
       - name: Set up Python
         uses: actions/setup-python@v3


### PR DESCRIPTION
## Summary

Follow-up cleanup to the trusted-publishing migration (#1319). Removes `registry-url`/`scope` from the `actions/setup-node` step in the release workflow.

## Why

When `registry-url` is set, `setup-node` writes a token-auth `.npmrc` that includes the deprecated `always-auth` config and a `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` line. On Node 24 (npm 11+) this produces:

```
npm warn Unknown user config "always-auth". This will stop working in the next major version of npm.
```

With trusted publishing (OIDC) there is no stored token — npm mints a short-lived token at publish time — so that `.npmrc` is dead weight (the authToken line is empty now that `NPM_TOKEN` is gone).

## Change

- Drop `registry-url` and `scope` from the `setup-node` step in `nx-release.yaml`.
- Registry still defaults to `https://registry.npmjs.org`; OIDC auth is unaffected.

No functional change to publishing — this only removes the warning and the leftover token-auth plumbing.
